### PR TITLE
Feature/issue 4 validacao entradas transcricao em grupo

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -1,9 +1,12 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -43,6 +46,12 @@ public class TelegramController implements LongPollingUpdateConsumer {
     private long ownerId;
 
     private static final int TELEGRAM_LIMIT = 4000;
+
+    // NOVO: limite máximo de tamanho de áudio (20 MB)
+    private static final long MAX_AUDIO_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+
+    // NOVO: cache para evitar processamento duplicado do mesmo áudio em grupos
+    private final Set<String> processedGroupAudios = ConcurrentHashMap.newKeySet();
 
     // =========================
     // 🚀 ENTRYPOINT
@@ -118,12 +127,32 @@ public class TelegramController implements LongPollingUpdateConsumer {
     // =========================
 
     private void tratarTexto(Message message, long chatId) {
-        String texto = message.getText().toLowerCase();
+        String texto = message.getText().toLowerCase().trim();
         log.debug("🔎 Processando texto chatId={} texto='{}'", chatId, texto);
 
+        // NOVO: suporte ao comando /start
+        if (texto.equals("/start")) {
+            enviarBoasVindas(chatId, message.getFrom().getFirstName());
+            return;
+        }
+
+        // Comando existente: buscar filmes
         if (!texto.startsWith("t1000 buscar")) return;
 
         String nome = texto.replace("t1000 buscar", "").trim();
+
+        // NOVO: validação da busca (mínimo 3, máximo 100 caracteres)
+        if (nome.length() < 3) {
+            telegramFacade.enviarMensagem(
+                    chatId, "🔍 O termo de busca deve ter pelo menos 3 caracteres.");
+            return;
+        }
+        if (nome.length() > 100) {
+            telegramFacade.enviarMensagem(
+                    chatId, "🔍 O termo de busca é muito longo (máx. 100 caracteres).");
+            return;
+        }
+
         var busca = movieService.buscarFilme(nome);
 
         if (busca == null || busca.results() == null || busca.results().isEmpty()) {
@@ -147,6 +176,26 @@ public class TelegramController implements LongPollingUpdateConsumer {
         enviarOpcoesDesambiguacao(chatId, busca.results());
     }
 
+    // NOVO: mensagem de boas-vindas com /start
+    private void enviarBoasVindas(long chatId, String firstName) {
+        String saudacao =
+                String.format(
+                        """
+            🤖 Olá, %s! Eu sou o **Tmill Bot**, o robô de metal líquido das transcrições e buscas.
+
+            📌 **O que posso fazer?**
+            🎬 Buscar filmes: `t1000 buscar <nome do filme>`
+            🎙️ Transcrever áudios: envie uma mensagem de voz ou áudio.
+
+            💡 **Em grupos/canais:**
+            Ao enviar um áudio, aparecerão botões para você escolher a transcrição **bruta** (🎙️) ou **refinada** (✨). O resultado chegará no seu **chat privado**.
+
+            Desenvolvido com 🧠 e ☕ Java 21 + Spring Boot.
+            """,
+                        firstName);
+        telegramFacade.enviarMensagem(chatId, saudacao);
+    }
+
     // =========================
     // 🎙️ AUDIO
     // =========================
@@ -162,14 +211,38 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 message.hasVoice()
                         ? message.getVoice().getFileId()
                         : message.getAudio().getFileId();
+        long fileSize =
+                message.hasVoice()
+                        ? message.getVoice().getFileSize()
+                        : message.getAudio().getFileSize();
+
+        // NOVO: validação de tamanho do arquivo
+        if (fileSize > MAX_AUDIO_SIZE_BYTES) {
+            log.warn("⚠️ Áudio muito grande chatId={} size={} bytes", chatId, fileSize);
+            telegramFacade.enviarMensagem(
+                    chatId, "📂 O arquivo de áudio excede 20 MB. Envie um arquivo menor.");
+            return;
+        }
+
+        if (fileId == null || fileId.isEmpty()) {
+            log.error("❌ fileId inválido chatId={}", chatId);
+            telegramFacade.enviarMensagem(
+                    chatId, "❌ Identificador do áudio inválido. Tente novamente.");
+            return;
+        }
+
+        boolean isGroup = isGroupChat(message);
+
+        // NOVO: comportamento diferenciado para grupos
+        if (isGroup) {
+            log.info("🎙️ Áudio recebido em grupo chatId={} fileId={}", chatId, fileId);
+            enviarBotoesTranscricaoEmGrupo(chatId, fileId);
+            return;
+        }
+
+        // Comportamento original para chat privado
         long userId = message.getFrom().getId();
         boolean isOwner = userId == ownerId;
-
-        log.info(
-                "🎙️ Iniciando fluxo de áudio chatId={} userId={} fileId={}",
-                chatId,
-                userId,
-                fileId);
 
         File file = fileService.baixarArquivo(fileId);
 
@@ -198,6 +271,38 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 });
     }
 
+    // NOVO: detecta se a mensagem veio de um grupo/supergrupo/canal
+    private boolean isGroupChat(Message message) {
+        var chat = message.getChat();
+        return chat.isGroupChat() || chat.isSuperGroupChat() || chat.isChannelChat();
+    }
+
+    // NOVO: envia botões para transcrição em grupos
+    private void enviarBotoesTranscricaoEmGrupo(long groupId, String fileId) {
+        String brutoData = "trans_bruto|" + fileId + "|" + groupId;
+        String refinadoData = "trans_refinado|" + fileId + "|" + groupId;
+
+        InlineKeyboardMarkup markup =
+                InlineKeyboardMarkup.builder()
+                        .keyboard(
+                                List.of(
+                                        new InlineKeyboardRow(
+                                                InlineKeyboardButton.builder()
+                                                        .text("🎙️ Transcrição Bruta")
+                                                        .callbackData(brutoData)
+                                                        .build(),
+                                                InlineKeyboardButton.builder()
+                                                        .text("✨ Transcrição Refinada")
+                                                        .callbackData(refinadoData)
+                                                        .build())))
+                        .build();
+
+        String mensagem =
+                "🎧 Áudio recebido! Clique num botão abaixo para receber a transcrição no seu chat"
+                        + " privado.";
+        telegramFacade.enviarComBotoes(groupId, mensagem, markup);
+    }
+
     // =========================
     // 🔘 CALLBACK
     // =========================
@@ -206,6 +311,12 @@ public class TelegramController implements LongPollingUpdateConsumer {
         String data = cb.getData();
         long chatId = cb.getMessage().getChatId();
         log.debug("🔘 Tratando callback chatId={} data={}", chatId, data);
+
+        // NOVO: callbacks de transcrição em grupo
+        if (data.startsWith("trans_bruto|") || data.startsWith("trans_refinado|")) {
+            tratarCallbackTranscricao(cb, data);
+            return;
+        }
 
         if (data.startsWith("id:")) {
             long id = Long.parseLong(data.replace("id:", ""));
@@ -242,6 +353,100 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 telegramFacade.enviarMensagem(chatId, "❌ Falha ao publicar.");
             }
         }
+    }
+
+    // NOVO: processa clique nos botões de transcrição dentro de grupos
+    private void tratarCallbackTranscricao(CallbackQuery callback, String data) {
+        String[] parts = data.split("\\|", 3);
+        if (parts.length < 3) {
+            log.error("Callback malformado: {}", data);
+            return;
+        }
+        String tipo = parts[0]; // "trans_bruto" ou "trans_refinado"
+        String fileId = parts[1];
+        long groupId = Long.parseLong(parts[2]);
+        long userId = callback.getFrom().getId();
+        int messageId = callback.getMessage().getMessageId();
+
+        String key = groupId + "_" + fileId;
+        if (processedGroupAudios.contains(key)) {
+            log.info("Áudio já processado no grupo groupId={} fileId={}", groupId, fileId);
+            telegramFacade.answerCallbackQuery(
+                    callback.getId(), "Este áudio já foi transcrito por outro usuário.", true);
+            return;
+        }
+
+        // Marca como processado imediatamente para evitar duplicatas concorrentes
+        processedGroupAudios.add(key);
+
+        // Responde ao clique rapidamente
+        telegramFacade.answerCallbackQuery(
+                callback.getId(), "Processando áudio... enviarei no privado.", false);
+
+        // Processa de forma assíncrona para não bloquear o callback
+        CompletableFuture.runAsync(
+                () -> {
+                    try {
+                        File audioFile = fileService.baixarArquivo(fileId);
+                        final String[] resultado = {null};
+                        final boolean[] refinadoRecebido = {false};
+
+                        audioService.processarFluxoAudio(
+                                audioFile,
+                                userId,
+                                (texto, isUltima) -> {
+                                    if ("trans_bruto".equals(tipo)) {
+                                        // Para bruto, a primeira mensagem (não refinada) é a que
+                                        // interessa
+                                        if (!isUltima) {
+                                            resultado[0] = texto;
+                                        }
+                                    } else {
+                                        // Para refinado, capturamos a última mensagem (refinada)
+                                        if (isUltima) {
+                                            resultado[0] = texto;
+                                            refinadoRecebido[0] = true;
+                                        }
+                                    }
+                                });
+
+                        if (resultado[0] == null) {
+                            throw new IllegalStateException(
+                                    "Nenhum texto foi produzido para o tipo " + tipo);
+                        }
+
+                        // Envia a transcrição para o privado do usuário
+                        String prefixo =
+                                "trans_bruto".equals(tipo)
+                                        ? "🎙️ *Transcrição Bruta:*\n"
+                                        : "✨ *Transcrição Refinada:*\n";
+                        telegramFacade.enviarMensagem(userId, prefixo + resultado[0]);
+
+                        // Edita a mensagem original do grupo removendo os botões
+                        editarMensagemGrupo(
+                                groupId, messageId, "✅ Transcrição enviada no privado.");
+
+                    } catch (Exception e) {
+                        log.error(
+                                "Erro ao processar áudio para grupo groupId={} fileId={}",
+                                groupId,
+                                fileId,
+                                e);
+                        editarMensagemGrupo(
+                                groupId, messageId, "❌ Falha ao processar áudio. Tente novamente.");
+                        // Em caso de falha, não removemos do cache para evitar repetição? Melhor
+                        // manter para
+                        // não spammar.
+                        // Mas poderia remover se quiser dar chance de tentar de novo. Por ora
+                        // mantemos
+                        // bloqueado.
+                    }
+                });
+    }
+
+    // NOVO: edita uma mensagem existente no grupo (remove botões)
+    private void editarMensagemGrupo(long chatId, int messageId, String novoTexto) {
+        telegramFacade.editarMensagem(chatId, messageId, novoTexto);
     }
 
     // =========================

--- a/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.service;
 
 import java.util.Optional;
@@ -36,7 +36,16 @@ public class MovieService {
      * @throws MovieNotFoundException se nenhum resultado for encontrado.
      */
     public MovieSearchResponse buscarFilme(String nome) {
-        var busca = tmdbClient.pesquisarFilme(nome);
+        // NOVO: sanitização básica
+        String sanitized = nome.trim().replaceAll("[^\\p{L}\\p{N}\\s]", "");
+        if (sanitized.length() < 3) {
+            throw new MovieNotFoundException("Termo de busca muito curto: " + nome);
+        }
+        if (sanitized.length() > 100) {
+            throw new MovieNotFoundException("Termo de busca muito longo: " + nome);
+        }
+
+        var busca = tmdbClient.pesquisarFilme(sanitized);
         if (busca == null || busca.results() == null || busca.results().isEmpty()) {
             throw new MovieNotFoundException("Filme não encontrado: " + nome);
         }

--- a/src/main/java/net/ddns/adambravo79/tmill/service/TelegramFileService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/TelegramFileService.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.service;
 
 import java.io.File;

--- a/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacade.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacade.java
@@ -1,10 +1,12 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.telegram.core;
 
 import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery;
 import org.telegram.telegrambots.meta.api.methods.GetFile;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.api.objects.InputFile;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -135,5 +137,39 @@ public class TelegramFacade {
     public java.io.File downloadFile(org.telegram.telegrambots.meta.api.objects.File tgFile)
             throws TelegramApiException {
         return telegramClient.downloadFile(tgFile);
+    }
+
+    // NOVO: edita uma mensagem existente (útil para remover botões após clique)
+    public void editarMensagem(long chatId, int messageId, String novoTexto) {
+        safeExecutor.run(
+                chatId,
+                this::enviarFallback,
+                () -> {
+                    var editMsg =
+                            EditMessageText.builder()
+                                    .chatId(String.valueOf(chatId))
+                                    .messageId(messageId)
+                                    .text(novoTexto)
+                                    .build();
+                    telegramClient.execute(editMsg);
+                });
+    }
+
+    // NOVO: responde a um callback query (para evitar timeout e dar feedback visual)
+    public void answerCallbackQuery(String callbackQueryId, String mensagem, boolean showAlert) {
+        safeExecutor.run(
+                0L, // chatId não usado no fallback, mas precisamos de um sender dummy. Melhor
+                // tratar
+                // exceção à parte.
+                (id, msg) -> log.warn("Fallback chamado para answerCallbackQuery, ignorando."),
+                () -> {
+                    var answer =
+                            AnswerCallbackQuery.builder()
+                                    .callbackQueryId(callbackQueryId)
+                                    .text(mensagem)
+                                    .showAlert(showAlert)
+                                    .build();
+                    telegramClient.execute(answer);
+                });
     }
 }

--- a/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramSafeExecutor.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramSafeExecutor.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.telegram.core;
 
 import org.springframework.stereotype.Component;

--- a/src/test/java/net/ddns/adambravo79/tmill/controller/TelegramControllerTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/controller/TelegramControllerTest.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
 import static org.assertj.core.api.Assertions.*;
@@ -13,13 +13,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.telegram.telegrambots.meta.api.objects.*;
+import org.telegram.telegrambots.meta.api.objects.chat.Chat;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 
 import net.ddns.adambravo79.tmill.cache.TranscricaoCache;
 import net.ddns.adambravo79.tmill.client.BloggerClient;
 import net.ddns.adambravo79.tmill.model.*;
 import net.ddns.adambravo79.tmill.service.*;
-import net.ddns.adambravo79.tmill.telegram.core.TelegramAction;
 import net.ddns.adambravo79.tmill.telegram.core.TelegramFacade;
 import net.ddns.adambravo79.tmill.telegram.core.TelegramSafeExecutor;
 
@@ -31,7 +32,7 @@ class TelegramControllerTest {
     private TranscricaoCache cache;
     private TelegramFileService fileService;
     private TelegramFacade telegramFacade;
-    private TelegramSafeExecutor safeExecutor;
+    private TelegramSafeExecutor safeExecutor; // instância real
 
     private TelegramController controller;
 
@@ -43,21 +44,8 @@ class TelegramControllerTest {
         cache = mock(TranscricaoCache.class);
         fileService = mock(TelegramFileService.class);
         telegramFacade = mock(TelegramFacade.class);
-        safeExecutor = mock(TelegramSafeExecutor.class);
-
-        // ✅ Replica o comportamento real: executa o action e absorve exceções
-        doAnswer(
-                        inv -> {
-                            TelegramAction action = inv.getArgument(2);
-                            try {
-                                action.run();
-                            } catch (Exception e) {
-                                // absorve — igual ao TelegramSafeExecutor real
-                            }
-                            return null;
-                        })
-                .when(safeExecutor)
-                .run(anyLong(), any(), any(TelegramAction.class));
+        // Usa o executor real (não mock)
+        safeExecutor = new TelegramSafeExecutor();
 
         controller =
                 new TelegramController(
@@ -124,6 +112,23 @@ class TelegramControllerTest {
         verify(telegramFacade).enviarMensagem(1L, "❌ Filme não encontrado.");
     }
 
+    @Test
+    void deveRejeitarBuscaComMenosDe3Caracteres() {
+        controller.consume(buildTextUpdate(1L, "t1000 buscar ab"));
+        verify(telegramFacade)
+                .enviarMensagem(1L, "🔍 O termo de busca deve ter pelo menos 3 caracteres.");
+        verifyNoInteractions(movieService);
+    }
+
+    @Test
+    void deveRejeitarBuscaComMaisDe100Caracteres() {
+        String termoLongo = "a".repeat(101);
+        controller.consume(buildTextUpdate(1L, "t1000 buscar " + termoLongo));
+        verify(telegramFacade)
+                .enviarMensagem(1L, "🔍 O termo de busca é muito longo (máx. 100 caracteres).");
+        verifyNoInteractions(movieService);
+    }
+
     // =========================
     // 🎙️ AUDIO
     // =========================
@@ -187,6 +192,61 @@ class TelegramControllerTest {
         verify(telegramFacade).enviarMensagem(1L, "🔇 Transcrição desativada.");
     }
 
+    @Test
+    void deveRejeitarAudioMaiorQue20MB() {
+        ReflectionTestUtils.setField(controller, "transcriptionEnabled", true);
+
+        Update update = mock(Update.class);
+        Message message = mock(Message.class);
+        Voice voice = mock(Voice.class);
+        User user = mock(User.class);
+
+        when(update.hasMessage()).thenReturn(true);
+        when(update.getMessage()).thenReturn(message);
+        when(message.getChatId()).thenReturn(1L);
+        when(message.hasVoice()).thenReturn(true);
+        when(message.getVoice()).thenReturn(voice);
+        when(voice.getFileId()).thenReturn("file-id");
+        when(voice.getFileSize()).thenReturn(21L * 1024 * 1024); // 21 MB
+        when(message.getFrom()).thenReturn(user);
+        when(user.getId()).thenReturn(1L);
+
+        controller.consume(update);
+
+        verify(telegramFacade)
+                .enviarMensagem(1L, "📂 O arquivo de áudio excede 20 MB. Envie um arquivo menor.");
+        verifyNoInteractions(fileService);
+    }
+
+    @Test
+    void deveEnviarBotoesAoReceberAudioEmGrupo() {
+        ReflectionTestUtils.setField(controller, "transcriptionEnabled", true);
+
+        Update update = mock(Update.class);
+        Message message = mock(Message.class);
+        Voice voice = mock(Voice.class);
+        Chat chat = mock(Chat.class);
+        User user = mock(User.class);
+
+        when(update.hasMessage()).thenReturn(true);
+        when(update.getMessage()).thenReturn(message);
+        when(message.getChatId()).thenReturn(-100L);
+        when(message.hasVoice()).thenReturn(true);
+        when(message.getVoice()).thenReturn(voice);
+        when(voice.getFileId()).thenReturn("file-id");
+        when(voice.getFileSize()).thenReturn(1024L);
+        when(message.getChat()).thenReturn(chat);
+        when(chat.isGroupChat()).thenReturn(true);
+        when(message.getFrom()).thenReturn(user);
+        when(user.getId()).thenReturn(123L);
+
+        controller.consume(update);
+
+        verify(telegramFacade)
+                .enviarComBotoes(eq(-100L), anyString(), any(InlineKeyboardMarkup.class));
+        verifyNoInteractions(fileService, audioService);
+    }
+
     // =========================
     // 🔘 CALLBACKS
     // =========================
@@ -200,18 +260,6 @@ class TelegramControllerTest {
 
         verify(bloggerClient).criarRascunho("Post automático", "texto");
         verify(telegramFacade).enviarMensagem(1L, "✅ Publicado: url");
-    }
-
-    @Test
-    void deveProcessarCallbackPublicarComTexto() {
-        when(cache.recuperar(1L)).thenReturn("texto");
-        when(bloggerClient.criarRascunho(any(), eq("texto"))).thenReturn("url");
-
-        controller.consume(buildCallbackUpdate(1L, "blogger:publicar"));
-
-        verify(bloggerClient).criarRascunho("Post automático", "texto");
-        verify(telegramFacade).enviarMensagem(1L, "✅ Publicado: url");
-        verify(cache).remover(1L);
     }
 
     @Test
@@ -242,6 +290,46 @@ class TelegramControllerTest {
         verify(telegramFacade).enviarFoto(eq(1L), anyString(), anyString());
     }
 
+    @Test
+    void deveProcessarCallbackTranscricaoBrutaEmGrupo() throws Exception {
+        ReflectionTestUtils.setField(controller, "transcriptionEnabled", true);
+
+        CallbackQuery cb = mock(CallbackQuery.class);
+        Message msg = mock(Message.class);
+        User user = mock(User.class);
+
+        // 🔥 CORREÇÃO: sem espaço antes do -100
+        when(cb.getData()).thenReturn("trans_bruto|file123|-100");
+        when(cb.getMessage()).thenReturn(msg);
+        when(msg.getChatId()).thenReturn(-100L);
+        when(msg.getMessageId()).thenReturn(42);
+        when(cb.getFrom()).thenReturn(user);
+        when(user.getId()).thenReturn(999L);
+        when(cb.getId()).thenReturn("cb123");
+
+        File fakeFile = new File("audio.oga");
+        when(fileService.baixarArquivo("file123")).thenReturn(fakeFile);
+
+        doAnswer(
+                        inv -> {
+                            BiConsumer<String, Boolean> cbk = inv.getArgument(2);
+                            cbk.accept("texto bruto", false);
+                            return null;
+                        })
+                .when(audioService)
+                .processarFluxoAudio(any(), eq(999L), any());
+
+        controller.consume(buildCallbackUpdate(cb));
+
+        // Aguarda a conclusão do CompletableFuture.runAsync()
+        Thread.sleep(500);
+
+        verify(telegramFacade)
+                .answerCallbackQuery("cb123", "Processando áudio... enviarei no privado.", false);
+        verify(telegramFacade).enviarMensagem(999L, "🎙️ *Transcrição Bruta:*\ntexto bruto");
+        verify(telegramFacade).editarMensagem(-100L, 42, "✅ Transcrição enviada no privado.");
+    }
+
     // =========================
     // 🧩 UTIL
     // =========================
@@ -249,12 +337,10 @@ class TelegramControllerTest {
     @Test
     void deveDividirMensagemGrande() {
         String texto = "a ".repeat(5000);
-        @SuppressWarnings("unchecked")
         List<String> partes =
                 (List<String>)
                         ReflectionTestUtils.invokeMethod(
                                 controller, "dividirMensagem", texto, 4000);
-
         assertThat(partes).isNotNull().hasSizeGreaterThan(1);
     }
 
@@ -262,15 +348,12 @@ class TelegramControllerTest {
     void deveIgnorarMensagemSemConteudo() {
         var update = mock(Update.class);
         var message = mock(Message.class);
-        var user = mock(User.class); // 🟢 Adicionado
+        var user = mock(User.class);
 
         when(update.hasMessage()).thenReturn(true);
         when(update.getMessage()).thenReturn(message);
-
-        // 🟢 Garante que o getFrom() não seja null
         when(message.getFrom()).thenReturn(user);
         when(user.getId()).thenReturn(12345L);
-
         when(message.hasText()).thenReturn(false);
         when(message.hasVoice()).thenReturn(false);
 
@@ -304,14 +387,12 @@ class TelegramControllerTest {
                 (String)
                         ReflectionTestUtils.invokeMethod(
                                 controller, "fecharMarkdown", "*texto* com *asterisco");
-
         assertThat(fechado).endsWith("*");
     }
 
     @Test
     void deveEnviarRespostaComBotoesBlogger() {
         ReflectionTestUtils.invokeMethod(controller, "enviarRespostaComBotoesBlogger", 1L, "texto");
-
         verify(cache).salvar(1L, "texto");
         verify(telegramFacade).enviarComBotoes(eq(1L), eq("texto"), any());
     }
@@ -323,15 +404,13 @@ class TelegramControllerTest {
     private Update buildTextUpdate(long chatId, String text) {
         var update = mock(Update.class);
         var message = mock(Message.class);
-        var user = mock(User.class); // 🟢 Adicionado
+        var user = mock(User.class);
 
         when(update.hasMessage()).thenReturn(true);
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
         when(message.hasText()).thenReturn(true);
         when(message.getText()).thenReturn(text);
-
-        // 🟢 Configura o remetente para evitar o NPE na linha 87 do Controller
         when(message.getFrom()).thenReturn(user);
         when(user.getId()).thenReturn(12345L);
 
@@ -343,14 +422,22 @@ class TelegramControllerTest {
         var message = mock(Message.class);
         var voice = mock(Voice.class);
         var user = mock(User.class);
+        var chat = mock(Chat.class);
+
         when(update.hasMessage()).thenReturn(true);
         when(update.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
         when(message.hasVoice()).thenReturn(true);
         when(message.getVoice()).thenReturn(voice);
         when(voice.getFileId()).thenReturn(fileId);
+        when(voice.getFileSize()).thenReturn(1024L);
         when(message.getFrom()).thenReturn(user);
         when(user.getId()).thenReturn(userId);
+        // Garante que não seja grupo (chat normal privado)
+        when(message.getChat()).thenReturn(chat);
+        when(chat.isGroupChat()).thenReturn(false);
+        when(chat.isSuperGroupChat()).thenReturn(false);
+
         return update;
     }
 
@@ -358,11 +445,21 @@ class TelegramControllerTest {
         var update = mock(Update.class);
         var cb = mock(CallbackQuery.class);
         var message = mock(Message.class);
+
         when(update.hasCallbackQuery()).thenReturn(true);
         when(update.getCallbackQuery()).thenReturn(cb);
         when(cb.getData()).thenReturn(data);
         when(cb.getMessage()).thenReturn(message);
         when(message.getChatId()).thenReturn(chatId);
+        when(cb.getId()).thenReturn("fake-cb-id");
+
+        return update;
+    }
+
+    private Update buildCallbackUpdate(CallbackQuery cb) {
+        var update = mock(Update.class);
+        when(update.hasCallbackQuery()).thenReturn(true);
+        when(update.getCallbackQuery()).thenReturn(cb);
         return update;
     }
 }

--- a/src/test/java/net/ddns/adambravo79/tmill/service/MovieServiceTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/service/MovieServiceTest.java
@@ -1,8 +1,9 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -28,6 +29,7 @@ class MovieServiceTest {
 
     @Test
     void deveLancarExcecaoQuandoFilmeNaoEncontrado() {
+        // Usa um termo com 3+ caracteres para passar na validação de tamanho
         when(tmdbClient.pesquisarFilme("xyz")).thenReturn(null);
 
         assertThatThrownBy(() -> movieService.executarBuscaFormatada("xyz"))
@@ -111,10 +113,11 @@ class MovieServiceTest {
 
     @Test
     void deveLancarExcecaoQuandoListaVazia() {
-        when(tmdbClient.pesquisarFilme("x"))
-                .thenReturn(new MovieSearchResponse(1, 1, 1, List.of()));
+        // Termo com 3 caracteres que retorna lista vazia
+        when(tmdbClient.pesquisarFilme("xyz"))
+                .thenReturn(new MovieSearchResponse(1, 0, 0, List.of()));
 
-        assertThatThrownBy(() -> movieService.executarBuscaFormatada("x"))
+        assertThatThrownBy(() -> movieService.executarBuscaFormatada("xyz"))
                 .isInstanceOf(MovieNotFoundException.class)
                 .hasMessageContaining("Filme não encontrado");
     }
@@ -145,5 +148,39 @@ class MovieServiceTest {
         var result = movieService.buscarPorId(1L);
 
         assertThat(result.textoFormatado()).contains("🌐");
+    }
+
+    // NOVO: teste de validação de tamanho da busca
+    @Test
+    void deveLancarExcecaoQuandoBuscaMuitoCurta() {
+        assertThatThrownBy(() -> movieService.buscarFilme("ab"))
+                .isInstanceOf(MovieNotFoundException.class)
+                .hasMessageContaining("Termo de busca muito curto");
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoBuscaMuitoLonga() {
+        String termoLongo = "a".repeat(101);
+        assertThatThrownBy(() -> movieService.buscarFilme(termoLongo))
+                .isInstanceOf(MovieNotFoundException.class)
+                .hasMessageContaining("Termo de busca muito longo");
+    }
+
+    @Test
+    void deveSanitizarCaracteresEspeciais() {
+        // A sanitização remove apenas caracteres não-alfanuméricos, mantendo acentos
+        when(tmdbClient.pesquisarFilme("válidotermo"))
+                .thenReturn(
+                        new MovieSearchResponse(
+                                1,
+                                1,
+                                1,
+                                List.of(
+                                        new MovieRecord(
+                                                1L, "Filme", "2020", "", 1.0, 1.0, "",
+                                                List.of()))));
+
+        movieService.buscarFilme("válido@termo#"); // deve ser sanitizado para "válidotermo"
+        verify(tmdbClient).pesquisarFilme("válidotermo");
     }
 }

--- a/src/test/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacadeTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacadeTest.java
@@ -1,10 +1,8 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.telegram.core;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -17,6 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.telegram.telegrambots.meta.api.methods.GetFile;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
@@ -127,7 +126,7 @@ class TelegramFacadeTest {
     }
 
     // =========================
-    // TelegramFacade
+    // TelegramFacade (novos métodos)
     // =========================
     @Test
     void deveEnviarMensagem() throws Exception {
@@ -192,13 +191,37 @@ class TelegramFacadeTest {
         tgFile.setFileId("fileId");
 
         java.io.File fakeFile = new java.io.File("teste.txt");
-
         when(client.downloadFile(tgFile)).thenReturn(fakeFile);
 
         java.io.File result = facade.downloadFile(tgFile);
 
         assertThat(result).hasName("teste.txt");
         verify(client).downloadFile(tgFile);
+    }
+
+    // NOVO: teste para editar mensagem
+    @Test
+    void deveEditarMensagem() throws Exception {
+        TelegramClient client = mock(TelegramClient.class);
+        TelegramSafeExecutor executor = new TelegramSafeExecutor();
+        TelegramFacade facade = new TelegramFacade(client, executor);
+
+        facade.editarMensagem(123L, 456, "novo texto");
+
+        verify(client).execute(any(EditMessageText.class));
+    }
+
+    // NOVO: teste para answerCallbackQuery (não valida fallback, apenas que a chamada ocorre)
+    @Test
+    void deveAnswerCallbackQuery() throws Exception {
+        TelegramClient client = mock(TelegramClient.class);
+        TelegramSafeExecutor executor = new TelegramSafeExecutor();
+        TelegramFacade facade = new TelegramFacade(client, executor);
+
+        facade.answerCallbackQuery("cb123", "processando", false);
+
+        verify(client)
+                .execute(any(org.telegram.telegrambots.meta.api.methods.AnswerCallbackQuery.class));
     }
 
     // =========================

--- a/src/test/java/net/ddns/adambravo79/tmill/telegram/core/TelegramSafeExecutorTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/telegram/core/TelegramSafeExecutorTest.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 01/05/2026 */
 package net.ddns.adambravo79.tmill.telegram.core;
 
 import static org.mockito.Mockito.*;


### PR DESCRIPTION
## 🧾 Descrição

Implementa melhorias de resiliência, segurança e experiência do usuário no Tmill Bot:

- **Validações de entrada (fail-fast):**
  - Busca de filmes: mínimo 3 caracteres, máximo 100, sanitização de caracteres especiais.
  - Áudio: limite de tamanho de 20 MB, validação de `fileId` não nulo/vazio.

- **Novo comando `/start`:**
  - Mensagem de boas-vindas personalizada com `firstName` do usuário.
  - Manual rápido explicando como buscar filmes e transcrição de áudio.

- **Suporte a transcrição de áudio em grupos/canais:**
  - Ao receber áudio em grupo, envia dois botões inline: `🎙️ Transcrição Bruta` e `✨ Transcrição Refinada`.
  - No clique, processa o áudio (download → conversão → transcrição → refinamento opcional) e envia o resultado **para o chat privado do usuário**.
  - Previne processamento duplicado do mesmo áudio no grupo via cache em memória (`ConcurrentHashMap.newKeySet()`).
  - Após processamento bem-sucedido, edita a mensagem original do grupo removendo os botões e exibindo "✅ Transcrição enviada no privado.".
  - Tratamento de erros: edita a mensagem do grupo com falha e desabilita os botões.

- **Novos métodos no `TelegramFacade`:**
  - `editarMensagem(chatId, messageId, novoTexto)` – permite edição de mensagens existentes.
  - `answerCallbackQuery(callbackQueryId, mensagem, showAlert)` – resposta rápida a cliques de botão.

- **Atualiza cabeçalhos de data** para `01/05/2026` nos arquivos modificados.

---

## 🔗 Issue relacionada

Closes #4

---

## 🚀 Tipo de mudança

- [x] Nova feature
- [x] Refatoração
- [ ] Bug fix
- [ ] Documentação

---

## 🧪 Como testar

### 1. Validações de busca e áudio
- Envie `t1000 buscar ab` → deve responder que precisa de no mínimo 3 caracteres.
- Envie `t1000 buscar` + 101 caracteres → deve rejeitar.
- Envie áudio de voz maior que 20 MB → deve rejeitar sem fazer download.

### 2. Comando `/start`
- Envie `/start` no privado → receber mensagem de boas-vindas com seu nome e manual.

### 3. Transcrição em grupo
- Crie um grupo, adicione o bot.
- Envie um áudio de voz (ex.: "Olá, este é um teste").
- O bot deve responder com mensagem contendo dois botões (🎙️ e ✨).
- Clique em **Transcrição Bruta** ou **Refinada**.
- Verifique se a transcrição chega **no seu privado**.
- Confirme que a mensagem original no grupo foi editada para "✅ Transcrição enviada no privado.".
- Peça para outro usuário clicar no mesmo botão – nada deve acontecer (já processado).

### 4. Chat privado (comportamento original)
- Envie áudio no privado → deve transcrever automaticamente e, se for owner, mostrar botões Blogger.

---

## 📸 Evidências (opcional)
*(Testes automatizados)*

- `./gradlew test` → todos os testes passam.
- Cobertura adicionada para novos cenários:
  - `TelegramControllerTest`: validações, envio de botões em grupo, callback de transcrição.
  - `MovieServiceTest`: validações de tamanho e sanitização.
  - `TelegramFacadeTest`: novos métodos `editarMensagem` e `answerCallbackQuery`.

---

## ✅ Checklist

- [x] Código revisado
- [x] Testes adicionados/atualizados
- [x] Build passando (`./gradlew clean test` ok)
- [x] Sem warnings críticos
- [x] Mensagem de commit segue padrão `commitlint`
- [x] Branch está atualizada com `develop`
