### PR TITLE
fix(telegram-uiux): remover os botoes de opção de filmes após ser clicado um

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ obter-refresh-token.sh
 mile-stone.sh
 temp_audio/**
 **/temp_audio/
+logs_backup/logs/users_2026-05-02.txt
+logs_backup/logs/users_2026-05-03.txt

--- a/deploy.sh
+++ b/deploy.sh
@@ -86,7 +86,9 @@ run_container() {
         --name "$APP_NAME" \
         --restart unless-stopped \
         --env-file .env \
+        -e TZ=America/Sao_Paulo \
         -v "$DATA_PATH:/app/temp_audio" \
+        -v "$(pwd)/logs:/app/logs" \
         --memory="700m" \
         --cpus="0.8" \
         "$DOCKER_IMAGE" || {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
 
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.problems=warn
-org.gradle.configuration-cache.parallel=true
+#org.gradle.configuration-cache=true
+#org.gradle.configuration-cache.problems=warn
+#org.gradle.configuration-cache.parallel=true
 
 org.gradle.jvmargs=-Xmx512m -XX:MaxMetaspaceSize=256m -Dfile.encoding=UTF-8

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 02/05/2026 */
+/* (c) 2026 | 03/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
 import java.io.File;
@@ -435,6 +435,13 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 telegramFacade.enviarMensagem(
                         chatId, resposta.textoFormatado() + "\n\n_(sem imagem)_");
             }
+            // 🔥 Editar a mensagem original (com os botões) para remover o teclado e avisar que o
+            // filme
+            // foi selecionado
+            int messageId = cb.getMessage().getMessageId();
+            String newText =
+                    "✅ Filme selecionado: " + resposta.textoFormatado().split("\n")[0]; // título
+            telegramFacade.editarMensagem(chatId, messageId, newText); // remove o inline keyboard
             return;
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.application.name=tmill-bot
+spring.jmx.enabled=false
+
 bot.token=${TELEGRAM_BOT_TOKEN}
 
 # TMDB
@@ -38,4 +40,6 @@ logging.level.net.ddns.adambravo79.tmill=INFO
 telegram.owner.id=${TELEGRAM_OWNER_ID}
 telegram.bot.name=@t1000paneleiro_bot
 
-user.log.directory=logs
+user.log.directory=/app/logs
+
+management.endpoints.access.default=NONE


### PR DESCRIPTION
## 🧾 Descrição

Remove os botões de desambiguação após a escolha de um filme, evitando cliques repetidos e melhorando a experiência do usuário.

**O que muda:**
- Após o usuário clicar em uma opção de filme (callback `id:movieId`), a mensagem original que continha os botões é editada:
  - O texto é alterado para "✅ Filme selecionado: <título do filme>" (ou mantém o texto original, conforme preferência).
  - O teclado inline é removido (não é mais possível escolher outro filme).

**Comportamento antigo:** Os botões permaneciam na tela, permitindo que o mesmo usuário ou outros clicassem novamente, causando repetição.

## 🔗 Issue relacionada

Hotfix solicitado por @deCastroAlves.

## 🚀 Tipo de mudança

- [x] Bug fix (UX)
- [ ] Nova feature
- [ ] Refatoração
- [ ] Documentação

## 🧪 Como testar

1. Busque um termo que retorne múltiplos filmes (ex.: `t1000 buscar matrix`).
2. Clique em qualquer uma das opções.
3. Verifique que a mensagem original (com os botões) é atualizada com "✅ Filme selecionado: ..." e os botões desaparecem.
4. Tente clicar novamente na mesma opção (não deve haver botões).

## ✅ Checklist

- [x] Código revisado
- [ ] Testes adicionados (opcional, mas recomendado)
- [x] Build passando
- [x] Sem warnings críticos