### PR TITLE
feat(bot): cria o easter-egg especial - pensando no futuro

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
@@ -121,7 +121,8 @@ public class MovieService {
                         linkTmdb,
                         streamings,
                         elenco,
-                        escapeMarkdown(detalhes.overview()));
+                        escapeMarkdown(detalhes.overview()),
+                        getEasterEgg(id).orElse(""));
 
         String urlPoster =
                 detalhes.posterPath() != null && !detalhes.posterPath().isBlank()
@@ -149,5 +150,16 @@ public class MovieService {
                 .replace("]", "\\]")
                 .replace("(", "\\(")
                 .replace(")", "\\)");
+    }
+
+    private Optional<String> getEasterEgg(long movieId) {
+        if (movieId == 280L) {
+            return Optional.of(
+                    "\n\n"
+                            + "🤖 *Review do T-1000:* \"Eu já vi esse filme, e não gostei muito do"
+                            + " final\"");
+        }
+        // Futuro: adicionar outros IDs com mensagens especiais
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
## 🧾 Descrição

Adiciona um **easter egg** ao buscar o filme **Terminator 2** (movieId 280). Após a sinopse, será exibido um parágrafo extra com a mensagem:

> 🤖 *Review do T-1000:* "Eu já vi esse filme, e não gostei muito do final"

A implementação é **modular**: um método `getEasterEgg` retorna um `Optional<String>` que, no futuro, pode ser facilmente estendido para outros filmes (basta adicionar novos `movieId` no mapa ou carregar de um arquivo de configuração).

## 🔗 Issue relacionada

N/A (feature solicitada pelo mantenedor)

## 🚀 Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação

## 🧪 Como testar

1. Envie o comando `t1000 buscar terminator 2` ou `t1000 buscar O EXTERMINADOR DO FUTURO 2: O JULGAMENTO FINAL`.
2. Verifique que a resposta contém o texto extra **após a sinopse**, com o emoji 🤖 e a frase entre aspas.
3. Busque outro filme (ex.: `t1000 buscar matrix`) – o easter egg NÃO deve aparecer.

## 📸 Evidências (opcional)

*Exemplo de saída esperada:*
```
🎬 *O EXTERMINADOR DO FUTURO 2: O JULGAMENTO FINAL*
📅 Ano: 1991 
⭐ *Nota:* [8.1/10](https://www.themoviedb.org/movie/280)

📺 *Onde assistir:* Universal+ Amazon Channel

👥 *Elenco:* Arnold Schwarzenegger, Linda Hamilton, Edward Furlong, Robert Patrick, Earl Boen

📖 *Sinopse:* O jovem John Connor é a chave para a vitória da civilização sobre uma rebelião de robôs do futuro...

🤖 *Review do T-1000:* "Eu já vi esse filme, e não gostei muito do final"
```

## ✅ Checklist

- [x] Código revisado
- [x] Testes manuais realizados
- [x] Build passando (sem quebras)
- [x] Sem warnings críticos
- [x] Implementação modular para futuras expansões