### PR TITLE
feat(security): restringe grupos por lista branca (BOT_ALLOWED_CHATS) mas mantém privados livres

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -1,10 +1,12 @@
-/* (c) 2026 | 03/05/2026 */
+/* (c) 2026 | 04/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -60,27 +62,57 @@ public class TelegramController implements LongPollingUpdateConsumer {
     @Value("${telegram.bot.name:@t1000paneleiro_bot}")
     private String botUsername;
 
-    private static final long MAX_AUDIO_SIZE_BYTES =
-            20 * 1024 * 1024; // fallback, mas será substituído
+    // NOVO: Lista de grupos autorizados (via .env)
+    @Value("${bot.allowed-chats:}")
+    private String allowedChatsStr;
 
-    // Cache para evitar processamento duplicado do mesmo áudio em grupos
-    // private final Set<String> processedGroupAudios = ConcurrentHashMap.newKeySet();
+    private final Set<Long> allowedGroups = new HashSet<>();
+    private final Set<Long> warnedGroups = ConcurrentHashMap.newKeySet(); // evita spam de log
+
+    private static final long MAX_AUDIO_SIZE_BYTES = 20 * 1024 * 1024; // fallback
 
     // Cache para tokens curtos (callback data)
     private final Map<String, AudioRequest> pendingGroupAudio = new ConcurrentHashMap<>();
-
     private final ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
 
-    // Construtor ou método @PostConstruct para iniciar limpeza periódica
+    // =========================
+    // 🧹 INICIALIZAÇÃO
+    // =========================
     @PostConstruct
-    public void initCacheCleaner() {
+    public void init() {
+        // Carrega lista de grupos permitidos
+        if (allowedChatsStr != null && !allowedChatsStr.isBlank()) {
+            for (String s : allowedChatsStr.split(",")) {
+                try {
+                    long id = Long.parseLong(s.trim());
+                    // Aceita apenas IDs negativos (grupos/canais)
+                    if (id < 0) {
+                        allowedGroups.add(id);
+                    } else {
+                        log.warn(
+                                "ID positivo na lista de autorizados será ignorado (use APENAS"
+                                        + " grupos): {}",
+                                id);
+                    }
+                } catch (NumberFormatException e) {
+                    log.warn("Chat ID inválido na lista de autorizados: {}", s);
+                }
+            }
+            log.info("📋 Grupos autorizados: {}", allowedGroups);
+        } else {
+            log.info("📋 Nenhum grupo autorizado configurado – todos os grupos serão ignorados.");
+        }
+
+        // Limpeza periódica dos tokens
         cleaner.scheduleAtFixedRate(
                 () -> {
                     long now = System.currentTimeMillis();
-                    // Remover entradas com mais de 1 hora (3600000 ms)
                     pendingGroupAudio
                             .entrySet()
                             .removeIf(entry -> now - entry.getValue().timestamp() > 3600000);
+                    log.debug(
+                            "🧹 Cache de tokens limpo. Tamanho atual: {}",
+                            pendingGroupAudio.size());
                 },
                 1,
                 1,
@@ -105,12 +137,40 @@ public class TelegramController implements LongPollingUpdateConsumer {
         }
     }
 
+    // NOVO: Verifica se o chat está autorizado (privados sempre OK, grupos só se estiverem na
+    // lista)
+    private boolean isChatAllowed(long chatId) {
+        // Chats privados (ID positivo) são sempre permitidos
+        if (chatId > 0) return true;
+        // Grupos/canais (ID negativo) só são permitidos se estiverem na lista (ou se a lista
+        // estiver
+        // vazia -> comportamento antigo)
+        if (allowedGroups.isEmpty())
+            return true; // lista vazia = todos grupos permitidos (fallback seguro)
+        return allowedGroups.contains(chatId);
+    }
+
     // =========================
     // 🧠 CORE ROUTER
     // =========================
 
     private void processarUpdate(Update update) {
-        // --- LOG DE USUÁRIO APENAS COM VALIDAÇÃO DE NULL ---
+        // --- VALIDAÇÃO DE CHAT AUTORIZADO (antes de qualquer log ou processamento) ---
+        Long chatId = null;
+        if (update.hasMessage()) {
+            chatId = update.getMessage().getChatId();
+        } else if (update.hasCallbackQuery()) {
+            chatId = update.getCallbackQuery().getMessage().getChatId();
+        }
+        if (chatId != null && !isChatAllowed(chatId)) {
+            if (warnedGroups.add(chatId)) {
+                log.warn("⛔ Grupo não autorizado. Ignorando mensagens do chatId={}", chatId);
+            }
+            return; // abandona o processamento completamente
+        }
+        // --- FIM DA VALIDAÇÃO ---
+
+        // --- LOG DE USUÁRIO (apenas se o chat foi autorizado) ---
         if (update.hasCallbackQuery()) {
             var callback = update.getCallbackQuery();
             var from = callback != null ? callback.getFrom() : null;
@@ -139,13 +199,13 @@ public class TelegramController implements LongPollingUpdateConsumer {
         // --- FIM DO LOG ---
 
         if (update.hasCallbackQuery()) {
-            long chatId = update.getCallbackQuery().getMessage().getChatId();
+            long cbChatId = update.getCallbackQuery().getMessage().getChatId();
             log.info(
                     "🔘 Callback recebido chatId={} data={}",
-                    chatId,
+                    cbChatId,
                     update.getCallbackQuery().getData());
             safeExecutor.run(
-                    chatId,
+                    cbChatId,
                     telegramFacade::enviarMensagem,
                     () -> tratarCallback(update.getCallbackQuery()));
             return;
@@ -154,7 +214,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
         if (!update.hasMessage()) return;
 
         Message message = update.getMessage();
-        long chatId = message.getChatId();
+        long msgChatId = message.getChatId();
         long userId = message.getFrom().getId();
 
         String tipoMensagem;
@@ -175,15 +235,17 @@ public class TelegramController implements LongPollingUpdateConsumer {
         log.info("🎙️ Áudio recebido de {} (userId={})", nomeRemetente, message.getFrom().getId());
         if (message.hasVoice() || message.hasAudio()) {
             safeExecutor.run(
-                    chatId,
+                    msgChatId,
                     telegramFacade::enviarMensagem,
-                    () -> tratarFluxoAudio(message, chatId));
+                    () -> tratarFluxoAudio(message, msgChatId));
             return;
         }
 
         if (message.hasText()) {
             safeExecutor.run(
-                    chatId, telegramFacade::enviarMensagem, () -> tratarTexto(message, chatId));
+                    msgChatId,
+                    telegramFacade::enviarMensagem,
+                    () -> tratarTexto(message, msgChatId));
         }
     }
 
@@ -301,7 +363,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
 
         boolean isGroup = isGroupChat(message);
 
-        // Dentro de tratarFluxoAudio, ao detectar grupo:
         if (isGroup) {
             long senderId = message.getFrom().getId();
             String senderName = message.getFrom().getFirstName();
@@ -360,25 +421,20 @@ public class TelegramController implements LongPollingUpdateConsumer {
 
     private void enviarBotoesTranscricaoEmGrupo(
             long groupId, String fileId, String senderName, long senderId, int durationSeconds) {
-        // Gera token
+        // Gera token curto
         String token =
                 Long.toHexString(System.nanoTime())
                         + Integer.toHexString(fileId.hashCode() & 0xFFFF);
         if (token.length() > 20) token = token.substring(0, 20);
 
-        // Cria AudioRequest completo
         pendingGroupAudio.put(
                 token,
                 new AudioRequest(
                         fileId, groupId, System.currentTimeMillis(), senderId, senderName));
 
-        // Montagem da mensagem (opcional: incluir nome do remetente e duração)
-
-        // Formata duração
         long minutos = durationSeconds / 60;
         long segundos = durationSeconds % 60;
         String duracaoFormatada = String.format("%dmin e %ds", minutos, segundos);
-        // Opcional: mensagem especial se for muito longo
         String silasCastHint = (durationSeconds > 300) ? ", praticamente um SilasCast 🗣" : "";
 
         String mensagem =
@@ -403,7 +459,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                                         .build())))
                         .build();
 
-        // Envia com parseMode Markdown (já que temos asteriscos e emojis)
         telegramFacade.enviarComBotoes(groupId, mensagem, markup);
     }
 
@@ -431,17 +486,13 @@ public class TelegramController implements LongPollingUpdateConsumer {
                     && (fotoUrl.startsWith("http://") || fotoUrl.startsWith("https://"))) {
                 telegramFacade.enviarFoto(chatId, fotoUrl, resposta.textoFormatado());
             } else {
-                // Fallback: envia apenas o texto, com indicação de que não há imagem
                 telegramFacade.enviarMensagem(
                         chatId, resposta.textoFormatado() + "\n\n_(sem imagem)_");
             }
-            // 🔥 Editar a mensagem original (com os botões) para remover o teclado e avisar que o
-            // filme
-            // foi selecionado
+            // Edita a mensagem original dos botões removendo o teclado
             int messageId = cb.getMessage().getMessageId();
-            String newText =
-                    "✅ Filme selecionado: " + resposta.textoFormatado().split("\n")[0]; // título
-            telegramFacade.editarMensagem(chatId, messageId, newText); // remove o inline keyboard
+            String newText = "✅ Filme selecionado: " + resposta.textoFormatado().split("\n")[0];
+            telegramFacade.editarMensagem(chatId, messageId, newText);
             return;
         }
 
@@ -480,7 +531,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
         String tipo = parts[0];
         String token = parts[1];
 
-        // Log básico do clique
         long userId = callback.getFrom().getId();
         long chatId = callback.getMessage().getChatId();
         log.info(
@@ -490,7 +540,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 chatId,
                 token);
 
-        // Recupera o pedido (sem remover)
         AudioRequest request = pendingGroupAudio.get(token);
         if (request == null) {
             log.warn(
@@ -500,7 +549,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
             return;
         }
 
-        // Log completo: quem clicou e quem enviou o áudio original
         log.info(
                 "📊 Clique no botão {} | clicador={} (id={}) | áudio enviado por: {} (id={}) |"
                         + " chatId={} | token={}",
@@ -515,11 +563,9 @@ public class TelegramController implements LongPollingUpdateConsumer {
         String fileId = request.fileId();
         long groupId = request.groupId();
 
-        // Resposta imediata ao clique
         telegramFacade.answerCallbackQuery(
                 callback.getId(), "Processando áudio... enviarei no privado.", false);
 
-        // Processamento assíncrono
         CompletableFuture.runAsync(
                 () -> {
                     try {
@@ -530,16 +576,14 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                 audioFile,
                                 userId,
                                 (texto, isUltima) -> {
-                                    if ("trans_bruto".equals(tipo) && !isUltima) {
+                                    if ("trans_bruto".equals(tipo) && !isUltima)
                                         resultado[0] = texto;
-                                    } else if ("trans_refinado".equals(tipo) && isUltima) {
+                                    else if ("trans_refinado".equals(tipo) && isUltima)
                                         resultado[0] = texto;
-                                    }
                                 });
 
-                        if (resultado[0] == null) {
+                        if (resultado[0] == null)
                             throw new IllegalStateException("Nenhum texto produzido");
-                        }
 
                         String prefixo =
                                 tipo.equals("trans_bruto")
@@ -547,8 +591,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                         : "✨ Transcrição Refinada:\n";
                         String mensagem = prefixo + resultado[0];
 
-                        // Envia sem parseMode (texto puro) para evitar erros de caracteres
-                        // especiais
                         if (mensagem.length() > telegramMessageLimit) {
                             dividirMensagem(mensagem, telegramMessageLimit)
                                     .forEach(
@@ -572,14 +614,12 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                         && errorMsg.contains("403")
                                         && errorMsg.contains("can't initiate conversation");
 
-                        if (isForbidden) {
-                            // Tenta avisar no grupo que o usuário precisa iniciar conversa com o
-                            // bot
+                        if (isForbidden && groupId != 0) {
                             try {
-                                String userMention = "@" + callback.getFrom().getUserName();
-                                if (callback.getFrom().getUserName() == null) {
-                                    userMention = "Usuário";
-                                }
+                                String userMention =
+                                        callback.getFrom().getUserName() != null
+                                                ? "@" + callback.getFrom().getUserName()
+                                                : "Usuário";
                                 telegramFacade.enviarMensagem(
                                         groupId,
                                         "⚠️ "
@@ -596,7 +636,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                         ex);
                             }
                         } else {
-                            // Tenta enviar mensagem de erro privada para o usuário
                             try {
                                 telegramFacade.enviarMensagem(
                                         userId, "❌ Erro ao processar áudio: " + errorMsg);
@@ -622,7 +661,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
     private void enviarOpcoesDesambiguacao(long chatId, List<MovieRecord> resultados) {
         List<InlineKeyboardRow> rows = new ArrayList<>();
         InlineKeyboardRow current = new InlineKeyboardRow();
-
         var lista = resultados.stream().limit(10).toList();
 
         for (int i = 0; i < lista.size(); i++) {
@@ -641,7 +679,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 current = new InlineKeyboardRow();
             }
         }
-
         var markup = InlineKeyboardMarkup.builder().keyboard(rows).build();
         telegramFacade.enviarComBotoes(
                 chatId, "🧐 Encontrei vários resultados. Qual você quer?", markup);
@@ -699,15 +736,12 @@ public class TelegramController implements LongPollingUpdateConsumer {
             partes.add(texto.substring(0, corte));
             texto = texto.substring(corte).trim();
         }
-        if (!texto.isEmpty()) {
-            partes.add(texto);
-        }
+        if (!texto.isEmpty()) partes.add(texto);
         return partes;
     }
 
     private String fecharMarkdown(String texto) {
         long count = texto.chars().filter(c -> c == '*').count();
-        if (count % 2 != 0) return texto + "*";
-        return texto;
+        return (count % 2 != 0) ? texto + "*" : texto;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,4 @@ user.log.directory=logs
 logging.level.net.ddns.adambravo79.tmill=INFO
 
 bot.token=${TELEGRAM_BOT_TOKEN}
+bot.allowed-chats=${BOT_ALLOWED_CHATS:}


### PR DESCRIPTION
## 🧾 Descrição

Implementa restrição para grupos/canais utilizando uma lista branca configurável via `.env` (`BOT_ALLOWED_CHATS`).  
**Chats privados (IDs positivos) continuam sempre permitidos** – qualquer usuário pode interagir com o bot no privado sem precisar ser listado.

### Principais alterações

- Nova propriedade `bot.allowed-chats` no `application.properties` (mapeada para `BOT_ALLOWED_CHATS` no `.env`).
- Apenas grupos com ID negativo que estejam na lista são processados.
- Chats privados (ID > 0) são sempre aceitos.
- Se a lista estiver vazia, o comportamento anterior é mantido (todos os grupos são permitidos – fallback seguro).
- Logs de aviso para grupos não autorizados (apenas uma vez por grupo).

## 🔗 Issue relacionada

N/A (feature solicitada antes da versão 1.1.5)

## 🚀 Tipo de mudança

- [x] Nova feature
- [ ] Bug fix
- [ ] Refatoração
- [ ] Documentação

## 🧪 Como testar

1. Configure no `.env` do servidor:  
   `BOT_ALLOWED_CHATS=-1003703557250,-1003265590455,-5283244164`  
   (substitua pelos IDs dos grupos autorizados)
2. Reinicie o container com `./deploy-oci.sh restart`
3. Verifique os logs: deve aparecer `📋 Grupos autorizados: [...]`
4. Teste:
   - Em grupo autorizado → bot respende normalmente.
   - Em grupo não autorizado → bot ignora (log `WARN`).
   - No privado com qualquer usuário → bot responde normalmente.

## 📸 Evidências

*Log de inicialização:*
```
📋 Grupos autorizados: [-1003703557250, -1003265590455, -5283244164]
```

*Grupo não autorizado:*
```
⛔ Grupo não autorizado. Ignorando mensagens do chatId=-123456789
```

## ✅ Checklist

- [x] Código revisado
- [x] Testes manuais realizados (OCI)
- [x] Build passa local
- [x] Sem warnings críticos
- [x] Compatível com versões anteriores (lista vazia = todos grupos permitidos)