### PR TITLE
fix: ajustes visuais, correção easter eggs

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -15,6 +15,19 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_info "Fazendo login no Docker Hub (use suas credenciais)..."
 docker login || { log_info "Login manual necessário. Execute 'docker login' depois."; exit 1; }
 
+# Gerar arquivo de build info
+BUILD_DATE=$(date +"%Y-%m-%d %H:%M:%S")
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT=$(git rev-parse --short HEAD)
+mkdir -p src/main/resources
+cat > src/main/resources/build-info.properties <<EOF
+build.branch=${GIT_BRANCH}
+build.commit=${GIT_COMMIT}
+build.time=${BUILD_DATE}
+EOF
+
+log_info "Build info gerado: branch=${GIT_BRANCH}, commit=${GIT_COMMIT}, data=${BUILD_DATE}"
+
 # 2. Build da imagem
 log_info "Construindo imagem: ${IMAGE_NAME}:${LATEST_TAG}"
 docker build -t "${IMAGE_NAME}:${LATEST_TAG}" -t "${IMAGE_NAME}:${VERSION_TAG}" .

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
     id "com.diffplug.spotless" version "6.25.0"
 }
 
-
 group = 'net.ddns.adambravo79'
 version = '1.0.0'
 

--- a/config/easter-eggs.json
+++ b/config/easter-eggs.json
@@ -1,6 +1,6 @@
 {
   "13": "🧙 <b>Easter egg de Forest Gump:</b> \"A vida é como uma caixa de chocolates...\"",
-  "272": "🎸 <b>Easter egg do Marty McFly:< \"Isso é pesado, Doc!\"",
+  "105": "🎸 <b>Easter egg do Marty McFly:</b> \"Isso é pesado, Doc!\"",
   "280": "🤖 <b>Review do T-1000:</b> \"Eu já vi esse filme, e não gostei muito do final\"",
   "1124": "🤖 <b>Review do T-1000:</b> \"De acordo com o pessoal desse canal, é a obra-prima do Nolan, eu <tg-spoiler>particularmente discordo</tg-spoiler>.\""
 }

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -30,6 +30,7 @@ import net.ddns.adambravo79.tmill.client.BloggerClient;
 import net.ddns.adambravo79.tmill.dto.AudioRequest;
 import net.ddns.adambravo79.tmill.exception.MovieNotFoundException;
 import net.ddns.adambravo79.tmill.model.MovieRecord;
+import net.ddns.adambravo79.tmill.model.MovieSearchResponse;
 import net.ddns.adambravo79.tmill.service.*;
 import net.ddns.adambravo79.tmill.telegram.core.TelegramFacade;
 import net.ddns.adambravo79.tmill.telegram.core.TelegramSafeExecutor;
@@ -64,41 +65,26 @@ public class TelegramController implements LongPollingUpdateConsumer {
     @Value("${telegram.bot.name:@t1000paneleiro_bot}")
     private String botUsername;
 
-    // NOVO: Lista de grupos autorizados (via .env)
     @Value("${bot.allowed-chats:}")
     private String allowedChatsStr;
 
     private final Set<Long> allowedGroups = new HashSet<>();
-    private final Set<Long> warnedGroups = ConcurrentHashMap.newKeySet(); // evita spam de log
+    private final Set<Long> warnedGroups = ConcurrentHashMap.newKeySet();
     private final Set<Long> warnedUsersFor403 = ConcurrentHashMap.newKeySet();
 
-    private static final long MAX_AUDIO_SIZE_BYTES = 20 * 1024 * 1024; // fallback
-
-    // Cache para tokens curtos (callback data)
     private final Map<String, AudioRequest> pendingGroupAudio = new ConcurrentHashMap<>();
     private final ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
 
-    // =========================
-    // 🧹 INICIALIZAÇÃO
-    // =========================
     @PostConstruct
     public void init() {
-        // Carrega lista de grupos permitidos
         if (allowedChatsStr != null && !allowedChatsStr.isBlank()) {
             for (String s : allowedChatsStr.split(",")) {
                 try {
                     long id = Long.parseLong(s.trim());
-                    // Aceita apenas IDs negativos (grupos/canais)
-                    if (id < 0) {
-                        allowedGroups.add(id);
-                    } else {
-                        log.warn(
-                                "ID positivo na lista de autorizados será ignorado (use APENAS"
-                                        + " grupos): {}",
-                                id);
-                    }
+                    if (id < 0) allowedGroups.add(id);
+                    else log.warn("ID positivo ignorado (use apenas grupos): {}", id);
                 } catch (NumberFormatException e) {
-                    log.warn("Chat ID inválido na lista de autorizados: {}", s);
+                    log.warn("Chat ID inválido: {}", s);
                 }
             }
             log.info("📋 Grupos autorizados: {}", allowedGroups);
@@ -106,111 +92,63 @@ public class TelegramController implements LongPollingUpdateConsumer {
             log.info("📋 Nenhum grupo autorizado configurado – todos os grupos serão ignorados.");
         }
 
-        // Limpeza periódica dos tokens
         cleaner.scheduleAtFixedRate(
                 () -> {
                     long now = System.currentTimeMillis();
                     pendingGroupAudio
                             .entrySet()
                             .removeIf(entry -> now - entry.getValue().timestamp() > 3600000);
-                    log.debug(
-                            "🧹 Cache de tokens limpo. Tamanho atual: {}",
-                            pendingGroupAudio.size());
+                    log.debug("🧹 Cache de tokens limpo. Tamanho: {}", pendingGroupAudio.size());
                 },
                 1,
                 1,
                 TimeUnit.HOURS);
     }
 
-    // =========================
-    // 🚀 ENTRYPOINT
-    // =========================
-
     @Override
     public void consume(List<Update> updates) {
         if (updates == null || updates.isEmpty()) return;
-        log.info("📩 Recebidos {} updates do Telegram", updates.size());
+        log.info("📩 Recebidos {} updates", updates.size());
         updates.parallelStream().forEach(this::processarUpdate);
     }
 
     public void consume(Update update) {
         if (update != null) {
-            log.info("📩 Recebido update único do Telegram");
+            log.info("📩 Update único");
             processarUpdate(update);
         }
     }
 
-    // NOVO: Verifica se o chat está autorizado (privados sempre OK, grupos só se estiverem na
-    // lista)
     private boolean isChatAllowed(long chatId) {
-        // Chats privados (ID positivo) são sempre permitidos
         if (chatId > 0) return true;
-        // Grupos/canais (ID negativo) só são permitidos se estiverem na lista (ou se a lista
-        // estiver
-        // vazia -> comportamento antigo)
-        if (allowedGroups.isEmpty())
-            return true; // lista vazia = todos grupos permitidos (fallback seguro)
+        if (allowedGroups.isEmpty()) return true;
         return allowedGroups.contains(chatId);
     }
 
-    // =========================
-    // 🧠 CORE ROUTER
-    // =========================
-
     private void processarUpdate(Update update) {
-        // --- VALIDAÇÃO DE CHAT AUTORIZADO (antes de qualquer log ou processamento) ---
         Long chatId = null;
-        if (update.hasMessage()) {
-            chatId = update.getMessage().getChatId();
-        } else if (update.hasCallbackQuery()) {
+        if (update.hasMessage()) chatId = update.getMessage().getChatId();
+        else if (update.hasCallbackQuery())
             chatId = update.getCallbackQuery().getMessage().getChatId();
-        }
         if (chatId != null && !isChatAllowed(chatId)) {
-            if (warnedGroups.add(chatId)) {
-                log.warn("⛔ Grupo não autorizado. Ignorando mensagens do chatId={}", chatId);
-            }
-            return; // abandona o processamento completamente
+            if (warnedGroups.add(chatId)) log.warn("⛔ Grupo não autorizado: {}", chatId);
+            return;
         }
-        // --- FIM DA VALIDAÇÃO ---
 
-        // --- LOG DE USUÁRIO (apenas se o chat foi autorizado) ---
         if (update.hasCallbackQuery()) {
             var callback = update.getCallbackQuery();
             var from = callback != null ? callback.getFrom() : null;
             if (from != null) {
-                String name =
+                userLogger.logUser(
+                        from.getId(),
                         from.getFirstName()
-                                + (from.getLastName() != null ? " " + from.getLastName() : "");
-                userLogger.logUser(from.getId(), name, "callback:" + callback.getData());
+                                + (from.getLastName() != null ? " " + from.getLastName() : ""),
+                        "callback:" + callback.getData());
             }
-        } else if (update.hasMessage()) {
-            var message = update.getMessage();
-            var from = message != null ? message.getFrom() : null;
-            if (from != null) {
-                String name =
-                        from.getFirstName()
-                                + (from.getLastName() != null ? " " + from.getLastName() : "");
-                String action =
-                        message.hasText()
-                                ? "text"
-                                : (message.hasVoice()
-                                        ? "voice"
-                                        : (message.hasAudio() ? "audio" : "other"));
-                userLogger.logUser(from.getId(), name, "message:" + action);
-            }
-        }
-        // --- FIM DO LOG ---
-
-        if (update.hasCallbackQuery()) {
-            long cbChatId = update.getCallbackQuery().getMessage().getChatId();
-            log.info(
-                    "🔘 Callback recebido chatId={} data={}",
-                    cbChatId,
-                    update.getCallbackQuery().getData());
+            long cbChatId = callback.getMessage().getChatId();
+            log.info("🔘 Callback recebido chatId={} data={}", cbChatId, callback.getData());
             safeExecutor.run(
-                    cbChatId,
-                    telegramFacade::enviarMensagem,
-                    () -> tratarCallback(update.getCallbackQuery()));
+                    cbChatId, telegramFacade::enviarMensagem, () -> tratarCallback(callback));
             return;
         }
 
@@ -218,24 +156,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
 
         Message message = update.getMessage();
         long msgChatId = message.getChatId();
-        long userId = message.getFrom().getId();
-
-        String tipoMensagem;
-        if (message.hasText()) {
-            tipoMensagem = "texto";
-        } else if (message.hasVoice()) {
-            tipoMensagem = "voz";
-        } else if (message.hasAudio()) {
-            tipoMensagem = "áudio";
-        } else {
-            tipoMensagem = "outro";
-        }
-
-        String nomeRemetente = message.getFrom().getFirstName();
-        if (message.getFrom().getLastName() != null) {
-            nomeRemetente += " " + message.getFrom().getLastName();
-        }
-        log.info("🎙️ Áudio recebido de {} (userId={})", nomeRemetente, message.getFrom().getId());
         if (message.hasVoice() || message.hasAudio()) {
             safeExecutor.run(
                     msgChatId,
@@ -252,10 +172,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
         }
     }
 
-    // =========================
-    // 🎬 TEXTO
-    // =========================
-
     private void tratarTexto(Message message, long chatId) {
         String texto = message.getText().toLowerCase().trim();
         log.debug("🔎 Processando texto chatId={} texto='{}'", chatId, texto);
@@ -265,44 +181,32 @@ public class TelegramController implements LongPollingUpdateConsumer {
             return;
         }
 
-        // Dentro de tratarTexto, antes do bloco que verifica "t1000 buscar"
         if (texto.startsWith("t1000 anotar ideia")) {
-            // Extrai a ideia (remove o comando)
             String idea = texto.replace("t1000 anotar ideia", "").trim();
             if (idea.isEmpty()) {
                 telegramFacade.enviarMensagem(
                         chatId,
-                        "❓ Você precisa escrever a ideia após o comando. Exemplo: `T1000 anotar"
-                                + " ideia: fazer café`");
+                        "❓ Digite a ideia após o comando. Ex: `T1000 anotar ideia: fazer café`");
                 return;
             }
-            // Remove dois pontos iniciais se existirem
-            if (idea.startsWith(":") || idea.startsWith("：")) {
-                idea = idea.substring(1).trim();
-            }
+            if (idea.startsWith(":") || idea.startsWith("：")) idea = idea.substring(1).trim();
             if (idea.isEmpty()) {
                 telegramFacade.enviarMensagem(chatId, "❓ A ideia não pode ficar vazia.");
                 return;
             }
 
-            // Obtém dados do usuário
             var from = message.getFrom();
             String userName =
                     from.getFirstName()
                             + (from.getLastName() != null ? " " + from.getLastName() : "");
             long userId = from.getId();
-            long chatIdOriginal = chatId;
-            String chatName = "";
-            if (message.getChat().isGroupChat() || message.getChat().isSuperGroupChat()) {
-                chatName = message.getChat().getTitle();
-            } else {
-                chatName = "privado";
-            }
+            String chatName =
+                    (message.getChat().isGroupChat() || message.getChat().isSuperGroupChat())
+                            ? message.getChat().getTitle()
+                            : "privado";
 
-            // Salva a ideia
-            ideasLogger.saveIdea(userId, userName, chatIdOriginal, idea, chatName);
+            ideasLogger.saveIdea(userId, userName, chatId, idea, chatName);
 
-            // Envia para o admin (ownerId)
             String adminMsg =
                     String.format(
                             "💡 <b>Nova ideia</b>\n"
@@ -319,8 +223,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                             java.time.format.DateTimeFormatter.ofPattern(
                                                     "dd/MM/yyyy HH:mm:ss")));
             telegramFacade.enviarMensagemHtml(ownerId, adminMsg);
-
-            // Confirma para o usuário
             telegramFacade.enviarMensagemHtml(
                     chatId, "✅ Ideia registrada! Obrigado pela contribuição.");
             return;
@@ -329,34 +231,33 @@ public class TelegramController implements LongPollingUpdateConsumer {
         if (!texto.startsWith("t1000 buscar")) return;
 
         String nome = texto.replace("t1000 buscar", "").trim();
-
         if (nome.length() < 3) {
-            telegramFacade.enviarMensagem(
-                    chatId, "🔍 O termo de busca deve ter pelo menos 3 caracteres.");
+            telegramFacade.enviarMensagem(chatId, "🔍 O termo deve ter pelo menos 3 caracteres.");
             return;
         }
         if (nome.length() > 100) {
             telegramFacade.enviarMensagem(
-                    chatId, "🔍 O termo de busca é muito longo (máx. 100 caracteres).");
+                    chatId, "🔍 O termo é muito longo (máx. 100 caracteres).");
             return;
         }
-        var busca = movieService.buscarFilme(nome);
-        try {
 
-            if (busca == null || busca.results() == null || busca.results().isEmpty()) {
-                log.warn("⚠️ Filme não encontrado chatId={} query='{}'", chatId, nome);
-                telegramFacade.enviarMensagem(chatId, "❌ Filme não encontrado.");
-                return;
-            }
+        MovieSearchResponse busca;
+        try {
+            busca = movieService.buscarFilme(nome);
         } catch (MovieNotFoundException e) {
             telegramFacade.enviarMensagem(chatId, "❌ " + e.getMessage());
+            return;
+        }
+
+        if (busca == null || busca.results() == null || busca.results().isEmpty()) {
+            telegramFacade.enviarMensagem(chatId, "❌ Filme não encontrado.");
             return;
         }
 
         if (busca.results().size() == 1) {
             var id = busca.results().get(0).id();
             var resposta = movieService.buscarPorId(id);
-            log.info("✅ Filme encontrado único chatId={} movieId={}", chatId, id);
+            log.info("✅ Filme único chatId={} movieId={}", chatId, id);
             String fotoUrl = resposta.urlFoto();
             if (fotoUrl != null
                     && !fotoUrl.isBlank()
@@ -369,10 +270,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
             return;
         }
 
-        log.info(
-                "🧐 Vários resultados encontrados chatId={} total={}",
-                chatId,
-                busca.results().size());
+        log.info("🧐 Vários resultados: {} total={}", chatId, busca.results().size());
         enviarOpcoesDesambiguacao(chatId, busca.results());
     }
 
@@ -389,7 +287,9 @@ public class TelegramController implements LongPollingUpdateConsumer {
             💡 <b>Em grupos/canais:</b>
             Ao enviar um áudio, aparecerão botões para você escolher a transcrição <b>bruta</b> (🎙️) ou <b>refinada</b> (✨). O resultado chegará no seu <b>chat privado</b>.
 
-            Desenvolvido com 🧠 e ☕ Java 21 + Spring Boot.
+            💡 Dar sugestões de melhoria do Bot <code>t1000 anotar ideia Achar os pais adotivos do John Connor... </code>
+
+            Desenvolvido com 🧠 e ☕ Java 21 + Spring Boot e bom humor.
             """,
                         escapeHtml(firstName));
         telegramFacade.enviarMensagemHtml(chatId, saudacao);
@@ -545,7 +445,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
     private void tratarCallback(CallbackQuery cb) {
         String data = cb.getData();
         long chatId = cb.getMessage().getChatId();
-        log.debug("🔘 Tratando callback chatId={} data={}", chatId, data);
+        log.debug("🔘 callback chatId={} data={}", chatId, data);
 
         if (data.startsWith("trans_bruto|") || data.startsWith("trans_refinado|")) {
             tratarCallbackTranscricaoComToken(cb, data);
@@ -560,23 +460,19 @@ public class TelegramController implements LongPollingUpdateConsumer {
             if (fotoUrl != null
                     && !fotoUrl.isBlank()
                     && (fotoUrl.startsWith("http://") || fotoUrl.startsWith("https://"))) {
-                log.info("Texto formatado para o filme {}: {}", id, resposta.textoFormatado());
-                telegramFacade.enviarFoto(chatId, fotoUrl, resposta.textoFormatado());
+                telegramFacade.enviarFotoHtml(chatId, fotoUrl, resposta.textoFormatado());
             } else {
-                log.info("Texto formatado para o filme {}: {}", id, resposta.textoFormatado());
                 telegramFacade.enviarMensagemHtml(
                         chatId, resposta.textoFormatado() + "\n\n_(sem imagem)_");
             }
-            // Edita a mensagem original dos botões removendo o teclado
             int messageId = cb.getMessage().getMessageId();
             String newText = "✅ Filme selecionado: " + resposta.textoFormatado().split("\n")[0];
-            telegramFacade.editarMensagem(chatId, messageId, newText);
+            telegramFacade.editarMensagemHtml(chatId, messageId, newText);
             return;
         }
 
         if ("blogger:cancelar".equals(data)) {
             cache.remover(chatId);
-            log.info("🛑 Publicação cancelada chatId={}", chatId);
             telegramFacade.enviarMensagem(chatId, "❌ Publicação cancelada.");
             return;
         }
@@ -584,17 +480,14 @@ public class TelegramController implements LongPollingUpdateConsumer {
         if ("blogger:publicar".equals(data)) {
             String texto = cache.recuperar(chatId);
             if (texto == null) {
-                log.warn("⚠️ Nenhuma transcrição disponível para publicar chatId={}", chatId);
                 telegramFacade.enviarMensagem(chatId, "⚠️ Nenhuma transcrição disponível.");
                 return;
             }
             String url = bloggerClient.criarRascunho("Post automático", texto);
             if (url != null) {
-                log.info("✅ Publicação realizada chatId={} url={}", chatId, url);
                 telegramFacade.enviarMensagem(chatId, "✅ Publicado: " + url);
                 cache.remover(chatId);
             } else {
-                log.error("❌ Falha ao publicar no Blogger chatId={}", chatId);
                 telegramFacade.enviarMensagem(chatId, "❌ Falha ao publicar.");
             }
         }
@@ -738,17 +631,11 @@ public class TelegramController implements LongPollingUpdateConsumer {
         telegramFacade.editarMensagem(chatId, messageId, novoTexto);
     }
 
-    // =========================
-    // 🧩 UI HELPERS
-    // =========================
-
     private void enviarOpcoesDesambiguacao(long chatId, List<MovieRecord> resultados) {
         List<InlineKeyboardRow> rows = new ArrayList<>();
         InlineKeyboardRow current = new InlineKeyboardRow();
-        var lista = resultados.stream().limit(10).toList();
-
-        for (int i = 0; i < lista.size(); i++) {
-            var filme = lista.get(i);
+        for (int i = 0; i < resultados.size() && i < 10; i++) {
+            var filme = resultados.get(i);
             String ano =
                     (filme.releaseDate() != null && filme.releaseDate().length() >= 4)
                             ? " (" + filme.releaseDate().substring(0, 4) + ")"
@@ -758,7 +645,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
                             .text(filme.title() + ano)
                             .callbackData("id:" + filme.id())
                             .build());
-            if ((i + 1) % 2 == 0 || (i + 1) == lista.size()) {
+            if ((i + 1) % 2 == 0 || (i + 1) == resultados.size()) {
                 rows.add(current);
                 current = new InlineKeyboardRow();
             }
@@ -787,10 +674,6 @@ public class TelegramController implements LongPollingUpdateConsumer {
         telegramFacade.enviarComBotoes(chatId, texto, markup);
     }
 
-    // =========================
-    // ✂️ UTIL
-    // =========================
-
     private String escapeMarkdown(String text) {
         return text.replace("_", "\\_")
                 .replace("*", "\\*")
@@ -805,11 +688,10 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 .replace("+", "\\+")
                 .replace("-", "\\-")
                 .replace("=", "\\=")
-                // NÃO escapar o pipe (|) para preservar o spoiler
                 .replace("{", "\\{")
                 .replace("}", "\\}")
-                .replace(".", "\\.") // ✅ ESCAPA O PONTO
-                .replace("!", "\\!"); // ✅ ESCAPA EXCLAMAÇÃO (se necessário)
+                .replace(".", "\\.")
+                .replace("!", "\\!");
     }
 
     private List<String> dividirMensagem(String texto, int limite) {

--- a/src/main/java/net/ddns/adambravo79/tmill/model/MovieRecord.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/model/MovieRecord.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 27/04/2026 */
+/* (c) 2026 | 07/05/2026 */
 package net.ddns.adambravo79.tmill.model;
 
 import java.util.List;
@@ -19,8 +19,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MovieRecord(
-        @JsonProperty("id") Long id, // ID necessário para buscar detalhes extras
+        @JsonProperty("id") Long id,
         String title,
+        @JsonProperty("original_title") String originalTitle, // 🆕
         @JsonProperty("release_date") String releaseDate,
         String overview,
         Double popularity,

--- a/src/main/java/net/ddns/adambravo79/tmill/service/BuildInfoService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/BuildInfoService.java
@@ -1,0 +1,37 @@
+package net.ddns.adambravo79.tmill.service;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class BuildInfoService {
+
+    @PostConstruct
+    public void logBuildInfo() {
+        try {
+            ClassPathResource resource = new ClassPathResource("build-info.properties");
+            if (resource.exists()) {
+                Properties props = new Properties();
+                try (InputStream is = resource.getInputStream()) {
+                    props.load(is);
+                }
+                log.info(
+                        "🚀 Build info - branch: {}, commit: {}, data: {}",
+                        props.getProperty("build.branch", "?"),
+                        props.getProperty("build.commit", "?"),
+                        props.getProperty("build.time", "?"));
+            } else {
+                log.info("🚀 Build info não disponível (build-info.properties não encontrado)");
+            }
+        } catch (Exception e) {
+            log.warn("Não foi possível ler informações de build", e);
+        }
+    }
+}

--- a/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/MovieService.java
@@ -116,6 +116,7 @@ public class MovieService {
                 String.format(
                         """
             🎬 <b>%s</b>
+            <i>%s</i>
             📅 Ano: %s %s
             ⭐ <b>Nota:</b> <a href="%s">%.1f/10</a>
 
@@ -128,13 +129,15 @@ public class MovieService {
             📺 <b>Onde assistir:</b> %s%s
             """,
                         detalhes.title().toUpperCase(),
+                        escapeHtml(
+                                detalhes.originalTitle() != null ? detalhes.originalTitle() : ""),
                         ano,
                         bandeiras,
                         linkTmdb,
                         detalhes.voteAverage(),
                         (diretor != null && !diretor.isBlank()) ? diretor : "N/A",
                         elenco,
-                        escapeHtml(detalhes.overview()), // novo método para escapar HTML
+                        escapeHtml(detalhes.overview()),
                         streamings,
                         easterEggService.getEasterEgg(id).map(egg -> "\n\n" + egg).orElse(""));
 

--- a/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacade.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/telegram/core/TelegramFacade.java
@@ -223,11 +223,6 @@ public class TelegramFacade {
 
     // NOVO: enviar foto com legenda em HTML
     public void enviarFotoHtml(long chatId, String url, String legenda) {
-        if (legenda == null || legenda.isBlank()) {
-            // sem legenda, envia sem parseMode
-            enviarFoto(chatId, url, ""); // ou implementa diretamente
-            return;
-        }
         safeExecutor.run(
                 chatId,
                 this::enviarFallback,
@@ -237,7 +232,7 @@ public class TelegramFacade {
                                     .chatId(String.valueOf(chatId))
                                     .photo(new InputFile(url))
                                     .caption(legenda)
-                                    .parseMode(HTML)
+                                    .parseMode(HTML) // ← ESSENCIAL
                                     .build();
                     telegramClient.execute(photo);
                 });
@@ -257,6 +252,22 @@ public class TelegramFacade {
                                     .parseMode(HTML)
                                     .build();
                     telegramClient.execute(msg);
+                });
+    }
+
+    public void editarMensagemHtml(long chatId, int messageId, String novoTexto) {
+        safeExecutor.run(
+                chatId,
+                this::enviarFallback,
+                () -> {
+                    var editMsg =
+                            EditMessageText.builder()
+                                    .chatId(String.valueOf(chatId))
+                                    .messageId(messageId)
+                                    .text(novoTexto)
+                                    .parseMode(HTML)
+                                    .build();
+                    telegramClient.execute(editMsg);
                 });
     }
 }

--- a/src/main/resources/easter-eggs.json
+++ b/src/main/resources/easter-eggs.json
@@ -1,6 +1,6 @@
 {
   "13": "🧙 <b>Easter egg de Forest Gump:</b> \"A vida é como uma caixa de chocolates...\"",
-  "272": "🎸 <b>Easter egg do Marty McFly:< \"Isso é pesado, Doc!\"",
+  "105": "🎸 <b>Easter egg do Marty McFly:</b> \"Isso é pesado, Doc!\"",
   "280": "🤖 <b>Review do T-1000:</b> \"Eu já vi esse filme, e não gostei muito do final\"",
   "1124": "🤖 <b>Review do T-1000:</b> \"De acordo com o pessoal desse canal, é a obra-prima do Nolan, eu <tg-spoiler>particularmente discordo</tg-spoiler>.\""
 }

--- a/src/test/java/net/ddns/adambravo79/tmill/client/TmdbClientTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/client/TmdbClientTest.java
@@ -43,6 +43,7 @@ class TmdbClientTest {
         var filme =
                 new MovieRecord(
                         1L,
+                        "Duna",
                         "Dune",
                         "2021-10-01",
                         "overview",
@@ -56,7 +57,7 @@ class TmdbClientTest {
         MovieSearchResponse result = new TmdbClient(restClient).pesquisarFilme("duna");
 
         assertThat(result.results()).hasSize(1);
-        assertThat(result.results().get(0).title()).isEqualTo("Dune");
+        assertThat(result.results().get(0).title()).isEqualTo("Duna");
     }
 
     // 🔥 ALTERADO: não lança exceção, retorna busca vazia
@@ -77,6 +78,7 @@ class TmdbClientTest {
         var movie =
                 new MovieRecord(
                         2L,
+                        "Batman",
                         "Batman",
                         "2022-03-01",
                         "overview",

--- a/src/test/java/net/ddns/adambravo79/tmill/controller/TelegramControllerTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/controller/TelegramControllerTest.java
@@ -83,7 +83,8 @@ class TelegramControllerTest {
                         1,
                         List.of(
                                 new MovieRecord(
-                                        id, "Duna", "2021", "desc", 1.0, 1.0, "", List.of())));
+                                        id, "Duna", "Dune", "2021", "desc", 1.0, 1.0, "",
+                                        List.of())));
 
         when(movieService.buscarFilme("duna")).thenReturn(search);
         when(movieService.buscarPorId(id)).thenReturn(new MovieOrchestrationResponse("ok", "url"));
@@ -102,8 +103,9 @@ class TelegramControllerTest {
                         1,
                         1,
                         List.of(
-                                new MovieRecord(1L, "A", "2020", "", 1.0, 1.0, "", List.of()),
-                                new MovieRecord(2L, "B", "2021", "", 1.0, 1.0, "", List.of())));
+                                new MovieRecord(1L, "A", "a", "2020", "", 1.0, 1.0, "", List.of()),
+                                new MovieRecord(
+                                        2L, "B", "b", "2021", "", 1.0, 1.0, "", List.of())));
 
         when(movieService.buscarFilme("teste")).thenReturn(search);
 
@@ -126,8 +128,7 @@ class TelegramControllerTest {
     @Test
     void deveRejeitarBuscaComMenosDe3Caracteres() {
         controller.consume(buildTextUpdate(1L, "t1000 buscar ab"));
-        verify(telegramFacade)
-                .enviarMensagem(1L, "🔍 O termo de busca deve ter pelo menos 3 caracteres.");
+        verify(telegramFacade).enviarMensagem(1L, "🔍 O termo deve ter pelo menos 3 caracteres.");
         verifyNoInteractions(movieService);
     }
 
@@ -136,7 +137,7 @@ class TelegramControllerTest {
         String termoLongo = "a".repeat(101);
         controller.consume(buildTextUpdate(1L, "t1000 buscar " + termoLongo));
         verify(telegramFacade)
-                .enviarMensagem(1L, "🔍 O termo de busca é muito longo (máx. 100 caracteres).");
+                .enviarMensagem(1L, "🔍 O termo é muito longo (máx. 100 caracteres).");
         verifyNoInteractions(movieService);
     }
 
@@ -304,7 +305,8 @@ class TelegramControllerTest {
 
         verify(movieService).buscarPorId(123L);
         verify(telegramFacade)
-                .enviarFoto(eq(1L), eq("https://image.tmdb.org/t/p/w500/poster.jpg"), anyString());
+                .enviarFotoHtml(
+                        eq(1L), eq("https://image.tmdb.org/t/p/w500/poster.jpg"), anyString());
         verify(telegramFacade, never()).enviarMensagem(anyLong(), anyString());
     }
 

--- a/src/test/java/net/ddns/adambravo79/tmill/integration/AudioToPostIntegrationTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/integration/AudioToPostIntegrationTest.java
@@ -73,7 +73,8 @@ class AudioToPostIntegrationTest {
     void fluxoDeBuscaDeFilme() {
         var tmdbClient = mock(TmdbClient.class);
         var registro =
-                new MovieRecord(1L, "Duna", "2021", "desc", 8.5, 9.0, "poster.jpg", List.of());
+                new MovieRecord(
+                        1L, "Duna", "Dune", "2021", "desc", 8.5, 9.0, "poster.jpg", List.of());
         when(tmdbClient.pesquisarFilme("duna"))
                 .thenReturn(new MovieSearchResponse(1, 1, 1, List.of(registro)));
 

--- a/src/test/java/net/ddns/adambravo79/tmill/model/ModelTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/model/ModelTest.java
@@ -58,7 +58,15 @@ class ModelTest {
     void deveCriarMovieResponse() {
         MovieRecord movieRecord =
                 new MovieRecord(
-                        1L, "Titulo", "2020", "overview", 10.0, 8.0, "/poster", List.of("US"));
+                        1L,
+                        "Titulo",
+                        "Title",
+                        "2020",
+                        "overview",
+                        10.0,
+                        8.0,
+                        "/poster",
+                        List.of("US"));
         MovieResponse resp = new MovieResponse(List.of(movieRecord));
 
         assertThat(resp.results()).hasSize(1);

--- a/src/test/java/net/ddns/adambravo79/tmill/service/MovieServiceTest.java
+++ b/src/test/java/net/ddns/adambravo79/tmill/service/MovieServiceTest.java
@@ -64,7 +64,7 @@ class MovieServiceTest {
                                 1,
                                 List.of(
                                         new MovieRecord(
-                                                1L, "Filme", "2020", "", 1.0, 1.0, "",
+                                                1L, "Filme", "Movie", "2020", "", 1.0, 1.0, "",
                                                 List.of()))));
 
         movieService.buscarFilme("válido@termo#");
@@ -93,6 +93,7 @@ class MovieServiceTest {
                                         new MovieRecord(
                                                 id,
                                                 "O Agente Secreto",
+                                                "The Secret Agent",
                                                 "2025-09-10",
                                                 "desc",
                                                 10.0,
@@ -105,6 +106,7 @@ class MovieServiceTest {
                         new MovieRecord(
                                 id,
                                 "O Agente Secreto",
+                                "The Secret Agent",
                                 "2026-01-01",
                                 "desc",
                                 10.0,
@@ -134,7 +136,15 @@ class MovieServiceTest {
         stubEmptyEasterEgg();
         var movie =
                 new MovieRecord(
-                        1L, "O Agente Secreto", "2025-09-10", "desc", 10.0, 8.5, "/img", List.of());
+                        1L,
+                        "O Agente Secreto",
+                        "The Secret Agent",
+                        "2025-09-10",
+                        "desc",
+                        10.0,
+                        8.5,
+                        "/img",
+                        List.of());
         when(tmdbClient.buscarDetalhes(1L)).thenReturn(movie);
         when(tmdbClient.buscarElenco(1L)).thenReturn(List.of());
         when(tmdbClient.buscarOndeAssistir(1L)).thenReturn("N/A");
@@ -147,7 +157,8 @@ class MovieServiceTest {
     void deveUsarTBAQuandoSemData() {
         stubEmptyEasterEgg();
         Long id = 1L;
-        var movie = new MovieRecord(id, "Teste", null, "desc", 1.0, 1.0, "/img", List.of("US"));
+        var movie =
+                new MovieRecord(id, "Teste", "Test", null, "desc", 1.0, 1.0, "/img", List.of("US"));
         when(tmdbClient.buscarDetalhes(id)).thenReturn(movie);
         when(tmdbClient.buscarElenco(id)).thenReturn(List.of());
         when(tmdbClient.buscarOndeAssistir(id)).thenReturn("N/A");
@@ -159,7 +170,9 @@ class MovieServiceTest {
     @Test
     void deveUsarGloboQuandoPaisInvalido() {
         stubEmptyEasterEgg();
-        var movie = new MovieRecord(1L, "Teste", "2020", "desc", 1.0, 1.0, "/img", List.of("XXX"));
+        var movie =
+                new MovieRecord(
+                        1L, "Teste", "Test", "2020", "desc", 1.0, 1.0, "/img", List.of("XXX"));
         when(tmdbClient.buscarDetalhes(1L)).thenReturn(movie);
         when(tmdbClient.buscarElenco(1L)).thenReturn(List.of());
         when(tmdbClient.buscarOndeAssistir(1L)).thenReturn("N/A");


### PR DESCRIPTION
## ✅ Pull Request: Consolidação de features e correções para a v1.2.0

### 🧾 Descrição

Este PR mescla diversas novas funcionalidades, melhorias e correções na branch `develop` em preparação para a próxima release (v1.2.0). Os principais destaques são:

1. **Easter eggs externalizados** (fecha #53)  
   - Os easter eggs são carregados de um arquivo JSON (`easter-eggs.json`) seja pelo classpath ou por um volume externo.  
   - Administradores podem recarregar o arquivo sem reiniciar o bot através de `POST /admin/reload-easter-eggs`.

2. **Novo comando: `t1000 anotar ideia`** (fecha #56)  
   - Usuários podem enviar ideias com `T1000 anotar ideia: <texto>`.  
   - As ideias são registradas diariamente em `logs/ideas_AAAA-MM-DD.txt` e encaminhadas ao dono do bot via mensagem privada.

3. **Migração para o parse mode HTML**  
   - Todas as mensagens formatadas (resultados de filmes, boas‑vindas, ideias) agora usam `parse_mode="HTML"`.  
   - Corrige erros de `can't parse entities` causados pelo MarkdownV2.  
   - Suporta tags nativas de spoiler com `<tg-spoiler>`.

4. **Melhorias na resposta dos filmes**  
   - Exibe o diretor (obtido da equipe do TMDB) em uma linha separada.  
   - Mostra o título original em inglês, em itálico, abaixo do título em português.

5. **Lista de restrição de grupos**  
   - A variável de ambiente `BOT_ALLOWED_CHATS` pode listar IDs específicos de grupos (números negativos).  
   - Chats privados são sempre permitidos; apenas grupos não listados são ignorados.

6. **Melhorias nos logs**  
   - `UserInteractionLogger` registra cada interação do usuário (texto, voz, áudio, callbacks).  
   - `IdeasLogger` armazena ideias dos usuários.  
   - Serviço `BuildInfoService` exibe no log a branch, commit e data/hora do build na inicialização.

7. **Melhorias no build e deploy**  
   - `build-and-push.sh` gera um arquivo `build-info.properties` com metadados do git.  
   - Dockerfile otimizado para tamanho menor, usando `amazoncorretto:21-alpine3.20`.  
   - `deploy-oci.sh` usa apenas `docker pull`, sem build local.

8. **Correções de bugs**  
   - Corrigido `BUTTON_DATA_INVALID` usando tokens curtos.  
   - Corrigido `AccessDeniedException` para o diretório de logs (chmod 777).  
   - Corrigido tratamento de `MovieNotFoundException` no `tratarTexto`.  
   - Corrigidos problemas de TLS e conexão removendo lançamentos desnecessários de exceção no `TmdbClient`.

### 🔗 Issues fechadas

- Fecha #53 – Easter eggs externalizados  
- Fecha #56 – Comando `T1000 anotar ideia`

### 🚀 Tipo de mudança

- [x] Nova funcionalidade  
- [x] Correção de bug  
- [x] Refatoração  
- [x] Documentação

### 🧪 Como testar

1. **Easter eggs**  
   - Coloque `config/easter-eggs.json` (ou use a versão do classpath).  
   - Execute `curl -X POST http://localhost:8082/admin/reload-easter-eggs` para recarregar.  
   - Busque `t1000 buscar terminator 2` – a mensagem do T-1000 deve aparecer com `<tg-spoiler>`.

2. **Anotar ideia**  
   - Envie `T1000 anotar ideia: testar integração` em qualquer chat.  
   - O dono do bot recebe uma mensagem privada; verifique o arquivo `logs/ideas_AAAA-MM-DD.txt`.

3. **Formatação HTML**  
   - Busque um filme – o título deve estar em negrito, o título original em itálico, a nota com link clicável, a linha do diretor, e os spoilers funcionando.

4. **Restrição de grupos**  
   - Defina `BOT_ALLOWED_CHATS=-100123456789` no `.env` e reinicie.  
   - Apenas aquele grupo será processado.

### 📸 Evidências (opcional)

*Exemplo de resposta após as alterações:*

```
🎬 DE VOLTA PARA O FUTURO
<i>BACK TO THE FUTURE</i>
📅 Ano: 1985 🇺🇸
⭐ Nota: 8,3/10

🎬 Diretor: Robert Zemeckis

👥 Elenco: Michael J. Fox, Christopher Lloyd...

📺 Onde assistir: HBO Max

🎸 Easter egg do Marty McFly: "Isso é pesado, Doc!"
```

### ✅ Checklist

- [x] Código revisado  
- [x] Testes atualizados e passando  
- [x] Build bem-sucedido  
- [x] Sem avisos críticos  
- [x] Documentação atualizada (comentários, README, exemplos de `.env`)
