### PR TITLE
Hotfix PR: Correções de timezone no digest, permissões SQLite e aviso 403

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
@@ -1,19 +1,28 @@
-/* (c) 2026 | 06/05/2026 */
+/* (c) 2026 | 09/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.ddns.adambravo79.tmill.service.DailyDigestService;
 import net.ddns.adambravo79.tmill.service.EasterEggService;
 
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
+@Slf4j
 public class AdminController {
 
     private final EasterEggService easterEggService;
@@ -35,5 +44,46 @@ public class AdminController {
     public ResponseEntity<String> testEveningDigest() {
         dailyDigestService.generateEveningDigest();
         return ResponseEntity.ok("Resumo da noite disparado.");
+    }
+
+    // AdminController.java
+    @GetMapping("/custom-digest")
+    public ResponseEntity<String> customDigest(
+            @RequestParam("start") String startDate, @RequestParam("end") String endDate) {
+
+        try {
+            LocalDate startLocalDate = null;
+            LocalDate endLocalDate = null;
+
+            // Tenta formatos diferentes
+            for (String pattern : new String[] {"yyyy-MM-dd", "dd-MM-yyyy"}) {
+                try {
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+                    startLocalDate = LocalDate.parse(startDate, formatter);
+                    endLocalDate = LocalDate.parse(endDate, formatter);
+                    break; // saiu do loop, conseguiu parsear
+                } catch (DateTimeParseException ignored) {
+                    /** */
+                }
+            }
+
+            if (startLocalDate == null || endLocalDate == null) {
+                return ResponseEntity.badRequest()
+                        .body(
+                                "Formato inválido. Use 'yyyy-MM-dd' ou 'dd-MM-yyyy'. Ex: 2026-05-07"
+                                        + " ou 07-05-2026");
+            }
+
+            ZoneId zone = ZoneId.of("America/Sao_Paulo");
+            LocalDateTime from = startLocalDate.atStartOfDay(zone).toLocalDateTime(); // 00:00
+            LocalDateTime to = endLocalDate.atTime(23, 59, 59); // 23:59:59
+
+            dailyDigestService.generateDigestCustom(from, to);
+            return ResponseEntity.ok(
+                    "Resumo personalizado gerado para período: " + startDate + " até " + endDate);
+        } catch (Exception e) {
+            log.error("Erro ao processar datas", e);
+            return ResponseEntity.internalServerError().body("Erro interno: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 07/05/2026 */
+/* (c) 2026 | 09/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
 import java.io.File;
@@ -75,7 +75,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
 
     private final Set<Long> allowedGroups = new HashSet<>();
     private final Set<Long> warnedGroups = ConcurrentHashMap.newKeySet();
-    private final Set<Long> warnedUsersFor403 = ConcurrentHashMap.newKeySet();
+    private final Set<String> warnedUsersFor403 = ConcurrentHashMap.newKeySet();
 
     private final Map<String, AudioRequest> pendingGroupAudio = new ConcurrentHashMap<>();
     private final ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
@@ -735,7 +735,8 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                         && errorMsg.contains("can't initiate conversation");
 
                         if (isForbidden && groupId != 0) {
-                            if (warnedUsersFor403.add(userId)) {
+                            String warnKey = groupId + "_" + userId;
+                            if (warnedUsersFor403.add(warnKey)) {
                                 try {
                                     String userMention =
                                             callback.getFrom().getUserName() != null
@@ -747,9 +748,10 @@ public class TelegramController implements LongPollingUpdateConsumer {
                                                     + userMention
                                                     + ", você precisa iniciar uma conversa com o"
                                                     + " bot no privado antes de receber"
-                                                    + " transcrições. Envie /start para @"
+                                                    + " transcrições.\n"
+                                                    + "👉 Envie /start para @"
                                                     + botUsername
-                                                    + ".");
+                                                    + " no seu chat privado e tente novamente.");
                                 } catch (Exception ex) {
                                     log.error(
                                             "Falha ao enviar aviso de 403 para o grupo {}",

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.longpolling.interfaces.LongPollingUpdateConsumer;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.*;

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -738,10 +738,16 @@ public class TelegramController implements LongPollingUpdateConsumer {
                             String warnKey = groupId + "_" + userId;
                             if (warnedUsersFor403.add(warnKey)) {
                                 try {
+                                    User from = callback.getFrom();
+                                    String userDisplayName = from.getFirstName();
+                                    if (from.getLastName() != null
+                                            && !from.getLastName().isBlank()) {
+                                        userDisplayName += " " + from.getLastName();
+                                    }
                                     String userMention =
-                                            callback.getFrom().getUserName() != null
-                                                    ? "@" + callback.getFrom().getUserName()
-                                                    : "Usuário";
+                                            from.getUserName() != null
+                                                    ? "@" + from.getUserName()
+                                                    : userDisplayName;
                                     telegramFacade.enviarMensagem(
                                             groupId,
                                             "⚠️ "

--- a/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
@@ -94,16 +94,16 @@ public class DailyDigestService {
         // Buscar mensagens de texto
         List<Map<String, Object>> messages =
                 jdbcTemplate.queryForList(
-                        "SELECT user_name, text FROM messages WHERE timestamp BETWEEN ? AND ? ORDER"
-                                + " BY timestamp ASC",
+                        "SELECT user_name, text FROM messages WHERE datetime(timestamp,"
+                                + " 'localtime') BETWEEN ? AND ? ORDER BY timestamp ASC",
                         from,
                         to);
 
         // Buscar transcrições de áudio
         List<Map<String, Object>> transcripts =
                 jdbcTemplate.queryForList(
-                        "SELECT user_name, text FROM transcripts WHERE timestamp BETWEEN ? AND ?"
-                                + " ORDER BY timestamp ASC",
+                        "SELECT user_name, text FROM transcripts WHERE datetime(timestamp,"
+                                + " 'localtime') BETWEEN ? AND ? ORDER BY timestamp ASC",
                         from,
                         to);
 

--- a/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
@@ -53,6 +53,11 @@ public class DailyDigestService {
         }
     }
 
+    // DailyDigestService.java
+    public void generateDigestCustom(LocalDateTime from, LocalDateTime to) {
+        generateDigest(from, to, "PERÍODO PERSONALIZADO");
+    }
+
     // Resumo da manhã: cobre das 20:30 do dia anterior até 08:29 do dia atual
     @Scheduled(cron = "0 30 8 * * *", zone = "America/Sao_Paulo")
     public void generateMorningDigest() {

--- a/src/main/resources/build-info.properties
+++ b/src/main/resources/build-info.properties
@@ -1,3 +1,3 @@
-build.branch=develop
-build.commit=536411a
-build.time=2026-05-09 14:56:04
+build.branch=hotfix/horario-do-resumo
+build.commit=c00c5ad
+build.time=2026-05-09 21:20:12

--- a/src/main/resources/build-info.properties
+++ b/src/main/resources/build-info.properties
@@ -1,3 +1,3 @@
-build.branch=feature/resumo-diario-ia
-build.commit=5b83a7e
-build.time=2026-05-09 12:28:47
+build.branch=develop
+build.commit=536411a
+build.time=2026-05-09 14:56:04

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS messages (
     chat_id INTEGER NOT NULL,
     user_id INTEGER NOT NULL,
     user_name TEXT,
-    text TEXT,
+    text TEXT NOT NULL,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -13,5 +13,6 @@ CREATE TABLE IF NOT EXISTS transcripts (
     user_id INTEGER NOT NULL,
     user_name TEXT,
     text TEXT NOT NULL,
+    raw_text TEXT,
     timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## 🔥 Hotfix PR: Correções de timezone no digest, permissões SQLite e aviso 403

### 🧾 Descrição

Este hotfix resolve três problemas críticos identificados após a release v1.1.6:

1. **Digest diário sem mensagens (timezone)**  
   - O banco SQLite armazena `timestamp` em UTC, mas o digest usava horário local (`America/Sao_Paulo`) diretamente na cláusula `WHERE`.  
   - **Solução:** As consultas agora usam `datetime(timestamp, 'localtime')` para converter o campo antes da comparação.  
   - Com isso, o resumo passa a identificar corretamente as mensagens do período desejado (08:30–20:30 e 20:30–08:30).

2. **Erro `SQLITE_READONLY` ao salvar mensagens**  
   - O arquivo `data/t1000.db` no host pertencia a um usuário diferente do UID do `appuser` (1000) e com permissões restritas.  
   - **Solução:** No script `deploy-oci.sh`, ajustamos o proprietário para `1000:1000` e damos `chmod 666`, garantindo escrita.  
   - As mensagens de texto e transcrições voltam a ser salvas normalmente.

3. **Aviso para usuários que não iniciaram conversa (`403 Forbidden`)**  
   - Quando um usuário clica num botão de transcrição sem nunca ter falado com o bot no privado, o Telegram bloqueia o envio. Agora o bot envia uma mensagem **no grupo** mencionando o usuário e instruindo a enviar `/start`.  
   - Utiliza um `Set<String>` para evitar múltiplos avisos para o mesmo par (grupo + usuário).

### 📁 Arquivos alterados

- `deploy-oci.sh` – permissões do banco
- `src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java` – consultas com conversão de timezone
- `src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java` – tratamento 403 (`warnedUsersFor403` agora `Set<String>` e mensagem clara)
- `src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java` – (adicional) endpoint `/custom-digest` para gerar resumo em qualquer período (útil para testes e administração)

### 🔗 Issue relacionada

- Relacionado a #54 (resumo diário)  
- Resolve erro `SQLITE_READONLY`  
- Melhora experiência do usuário com erro 403

### 🧪 Como testar

1. **Após o deploy**, verifique se as mensagens de texto são salvas:
   ```bash
   sqlite3 data/t1000.db "SELECT COUNT(*) FROM messages;"
   ```
   (o número deve aumentar após enviar uma mensagem qualquer)

2. **Digest diário**:
   - Execute o digest da noite manualmente:  
     `curl http://localhost:8082/admin/test-evening-digest`  
   - O resumo deve aparecer no chat configurado em `digest.chat-ids`.

3. **Aviso 403**:
   - Em um grupo, peça para um usuário que **nunca falou com o bot no privado** enviar um áudio e clicar num botão.  
   - O bot deve enviar uma mensagem no grupo alertando o usuário e instruindo a enviar `/start` no privado.

4. **Endpoint customizado** (opcional):
   ```bash
   curl "http://localhost:8082/admin/custom-digest?start=07-05-2026&end=10-05-2026"
   ```

### ✅ Checklist

- [x] Permissões do banco corrigidas (escrita funcionando)
- [x] Digest com timezone corrigido
- [x] Aviso 403 claro e sem spam
- [x] Todos os testes manuais realizados no ambiente OCI
- [x] Versão estável para produção

### 🚀 Como aplicar

1. Faça o merge deste PR na branch `main`.
2. No servidor OCI, execute:
   ```bash
   git checkout main
   git pull origin main
   ./deploy-oci.sh deploy
   ```
3. Acompanhe os logs: `docker logs t1000-bot --tail 50 -f`

Após o merge, recomenda‑se criar a tag `v1.1.7` para marcar o hotfix.