### PR TITLE
fix: Adicionar métricas de cache (hits/misses) – `develop`

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/cache/TranscriptionCacheService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/cache/TranscriptionCacheService.java
@@ -1,10 +1,12 @@
 /* (c) 2026 | 09/05/2026 */
 package net.ddns.adambravo79.tmill.cache;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,16 +21,19 @@ public class TranscriptionCacheService {
     private final ConcurrentHashMap<String, TranscriptionCacheEntry> cache =
             new ConcurrentHashMap<>();
     private final ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
+    private final AtomicLong hits = new AtomicLong(0);
+    private final AtomicLong misses = new AtomicLong(0);
 
     @Value("${cache.transcription.enabled:true}")
     private boolean cacheEnabled;
 
-    @Value("${cache.transcription.ttl-seconds:86400}") // 24 horas padrão
+    @Value("${cache.transcription.ttl-seconds:86400}")
     private long ttlSeconds;
 
     @PostConstruct
-    public void startCleaner() {
+    public void startCleanerAndStatsLogger() {
         if (cacheEnabled) {
+            // Cleaner (remove entradas expiradas)
             cleaner.scheduleAtFixedRate(
                     () -> {
                         long now = System.currentTimeMillis();
@@ -50,6 +55,20 @@ public class TranscriptionCacheService {
                     1,
                     1,
                     TimeUnit.HOURS);
+
+            // Stats logger (a cada hora)
+            cleaner.scheduleAtFixedRate(
+                    () -> {
+                        log.info(
+                                "Cache stats: hits={}, misses={}, size={}",
+                                hits.get(),
+                                misses.get(),
+                                cache.size());
+                    },
+                    1,
+                    1,
+                    TimeUnit.HOURS);
+
             log.info("Cache de transcrições ativado (TTL: {} segundos)", ttlSeconds);
         } else {
             log.info("Cache de transcrições desativado");
@@ -60,9 +79,11 @@ public class TranscriptionCacheService {
         if (!cacheEnabled) return null;
         TranscriptionCacheEntry entry = cache.get(fileId);
         if (entry != null) {
+            hits.incrementAndGet();
             log.debug("Cache HIT para fileId={}", fileId);
             return entry;
         }
+        misses.incrementAndGet();
         log.debug("Cache MISS para fileId={}", fileId);
         return null;
     }
@@ -75,12 +96,18 @@ public class TranscriptionCacheService {
         log.info("Cache atualizado para fileId={} (tamanho atual: {})", fileId, cache.size());
     }
 
+    public Map<String, Long> getStats() {
+        return Map.of("hits", hits.get(), "misses", misses.get(), "size", (long) cache.size());
+    }
+
     public int size() {
         return cache.size();
     }
 
     public void clear() {
         cache.clear();
+        hits.set(0);
+        misses.set(0);
         log.info("Cache de transcrições limpo manualmente");
     }
 }

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
@@ -1,12 +1,12 @@
 /* (c) 2026 | 09/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
-import java.util.Map;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import net.ddns.adambravo79.tmill.cache.TranscriptionCacheService;
 import lombok.extern.slf4j.Slf4j;
+import net.ddns.adambravo79.tmill.cache.TranscriptionCacheService;
 import net.ddns.adambravo79.tmill.service.DailyDigestService;
 import net.ddns.adambravo79.tmill.service.EasterEggService;
 
@@ -52,6 +52,8 @@ public class AdminController {
     @GetMapping("/cache-stats")
     public ResponseEntity<Map<String, Long>> getCacheStats() {
         return ResponseEntity.ok(transcriptionCacheService.getStats());
+    }
+
     // AdminController.java
     @GetMapping("/custom-digest")
     public ResponseEntity<String> customDigest(

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/AdminController.java
@@ -1,6 +1,8 @@
 /* (c) 2026 | 06/05/2026 */
 package net.ddns.adambravo79.tmill.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import net.ddns.adambravo79.tmill.cache.TranscriptionCacheService;
 import net.ddns.adambravo79.tmill.service.DailyDigestService;
 import net.ddns.adambravo79.tmill.service.EasterEggService;
 
@@ -18,6 +21,7 @@ public class AdminController {
 
     private final EasterEggService easterEggService;
     private final DailyDigestService dailyDigestService;
+    private final TranscriptionCacheService transcriptionCacheService;
 
     @PostMapping("/reload-easter-eggs")
     public ResponseEntity<String> reloadEasterEggs() {
@@ -35,5 +39,10 @@ public class AdminController {
     public ResponseEntity<String> testEveningDigest() {
         dailyDigestService.generateEveningDigest();
         return ResponseEntity.ok("Resumo da noite disparado.");
+    }
+
+    @GetMapping("/cache-stats")
+    public ResponseEntity<Map<String, Long>> getCacheStats() {
+        return ResponseEntity.ok(transcriptionCacheService.getStats());
     }
 }


### PR DESCRIPTION
## 📥 Pull Request: Adicionar métricas de cache (hits/misses) – `develop`

### 🧾 Descrição

Adiciona contadores de acertos (hits) e erros (misses) no serviço de cache de transcrições (`TranscriptionCacheService`), além de um endpoint `/admin/cache-stats` para consultar as métricas em JSON.

**Mudanças:**

- `TranscriptionCacheService.java`:
  - `AtomicLong hits` e `AtomicLong misses`.
  - Incrementa contadores nos métodos `get()` (hit/miss) e `put()` (apenas atualiza tamanho).
  - Log periódico (a cada hora) das estatísticas.
  - Método `getStats()` retorna mapa com `hits`, `misses`, `size`.

- `AdminController.java`:
  - Endpoint `GET /admin/cache-stats` que retorna as métricas.

### 🔗 Issue relacionada

Ref. #53 (cache de transcrições) – métricas complementares.

### 🚀 Tipo de mudança

- [x] Melhoria
- [ ] Nova feature
- [ ] Bug fix

### 🧪 Como testar

1. Após o deploy, acesse:
   ```bash
   curl http://localhost:8082/admin/cache-stats
   ```
   Exemplo de saída:
   ```json
   {"hits":42,"misses":15,"size":12}
   ```

2. Acompanhe os logs do container: a cada hora aparecerá:
   ```
   INFO ... Cache stats: hits=42, misses=15, size=12
   ```

### ✅ Checklist

- [x] Código revisado
- [x] Logs e endpoint testados localmente
- [x] Sem conflitos com `develop`
