### PR TITLE
Corrige formato da data nas consultas do digest (hotfix)

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
@@ -96,21 +96,25 @@ public class DailyDigestService {
     private void generateDigest(LocalDateTime from, LocalDateTime to, String periodLabel) {
         log.info("Gerando {} período {} - {}", periodLabel, from, to);
 
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String fromStr = from.format(dtf);
+        String toStr = to.format(dtf);
+
         // Buscar mensagens de texto
         List<Map<String, Object>> messages =
                 jdbcTemplate.queryForList(
                         "SELECT user_name, text FROM messages WHERE datetime(timestamp,"
                                 + " 'localtime') BETWEEN ? AND ? ORDER BY timestamp ASC",
-                        from,
-                        to);
+                        fromStr,
+                        toStr);
 
         // Buscar transcrições de áudio
         List<Map<String, Object>> transcripts =
                 jdbcTemplate.queryForList(
                         "SELECT user_name, text FROM transcripts WHERE datetime(timestamp,"
                                 + " 'localtime') BETWEEN ? AND ? ORDER BY timestamp ASC",
-                        from,
-                        to);
+                        fromStr,
+                        toStr);
 
         if (messages.isEmpty() && transcripts.isEmpty()) {
             log.info("Nenhuma mensagem ou transcrição no período.");

--- a/src/main/resources/build-info.properties
+++ b/src/main/resources/build-info.properties
@@ -1,3 +1,3 @@
-build.branch=hotfix/horario-do-resumo
-build.commit=c00c5ad
-build.time=2026-05-09 21:20:12
+build.branch=hotfix/ajuste-no-select-dos-digests
+build.commit=925ae05
+build.time=2026-05-10 21:08:45


### PR DESCRIPTION
## 📥 Pull Request: Corrige formato da data nas consultas do digest (hotfix)

### 🧾 Descrição

Hotfix para o resumo diário (`DailyDigestService`). O problema: o `JdbcTemplate` convertia os parâmetros `LocalDateTime` para strings no formato ISO (`2026-05-10T08:30:00`), enquanto a coluna convertida com `datetime(timestamp, 'localtime')` gerava strings com espaço (`2026-05-10 08:30:00`). A comparação lexicográfica falhava devido ao caractere `'T'` vs `' '`, resultando em `Nenhuma mensagem ou transcrição no período` mesmo havendo registros.

**Solução:**  
Formatar manualmente as datas como strings `yyyy-MM-dd HH:mm:ss` antes de passar para a consulta SQL.

### 🔧 Alterações

- `DailyDigestService.java` – método `generateDigest`:
  - Adiciona `DateTimeFormatter` com padrão `yyyy-MM-dd HH:mm:ss`.
  - Converte `from` e `to` para strings nesse formato.
  - Usa essas strings nos parâmetros das consultas SQL.

### 🔗 Impacto

- Digest da manhã (08:30) e da noite (20:30) voltam a encontrar mensagens.
- Endpoint `/admin/custom-digest` também funciona (usa o mesmo método).

### 🧪 Como testar (após deploy)

1. No servidor OCI, execute:
   ```bash
   curl "http://localhost:8082/admin/custom-digest?start=2026-05-10&end=2026-05-10"
   ```
   Deve gerar resumo (se houver mensagens no dia).

2. Verifique os logs:
   ```bash
   docker logs t1000-bot --tail 30 | grep -i "resumo enviado"
   ```

### ✅ Checklist

- [x] Código revisado
- [x] Testado localmente (simulado)
- [x] Sem conflitos com `main`
