### PR TITLE
Correção de `raw_text` ausente e split de mensagem longa no cache (hotfix)

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/config/DatabaseInitializer.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/config/DatabaseInitializer.java
@@ -1,6 +1,9 @@
 /* (c) 2026 | 09/05/2026 */
 package net.ddns.adambravo79.tmill.config;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -33,12 +36,20 @@ public class DatabaseInitializer {
             )
         """);
         // se a tabela já existir sem a coluna raw_text, adiciona
+        // No método init(), após criar a tabela, adicione:
         try {
-            jdbcTemplate.execute("ALTER TABLE transcripts ADD COLUMN raw_text TEXT");
-            log.info("Coluna raw_text adicionada à tabela transcripts");
+            List<Map<String, Object>> columns =
+                    jdbcTemplate.queryForList("PRAGMA table_info(transcripts)");
+            boolean hasRawText =
+                    columns.stream().anyMatch(row -> "raw_text".equals(row.get("name")));
+            if (!hasRawText) {
+                jdbcTemplate.execute("ALTER TABLE transcripts ADD COLUMN raw_text TEXT");
+                log.info("Coluna raw_text adicionada à tabela transcripts");
+            } else {
+                log.debug("Coluna raw_text já existe");
+            }
         } catch (Exception e) {
-            // coluna já existe (ignorar erro)
-            log.debug("Coluna raw_text já presente na tabela transcripts");
+            log.error("Erro ao verificar/adicionar coluna raw_text", e);
         }
     }
 }

--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -664,7 +664,12 @@ public class TelegramController implements LongPollingUpdateConsumer {
                             : "✨ Transcrição Refinada:\n";
             String mensagem = prefixo + textoEscolhido;
             // ... enviar mensagem (igual ao fluxo normal)
-            telegramFacade.enviarMensagemSemMarkdown(userId, mensagem);
+            if (mensagem.length() > telegramMessageLimit) {
+                dividirMensagem(mensagem, telegramMessageLimit)
+                        .forEach(parte -> telegramFacade.enviarMensagemSemMarkdown(userId, parte));
+            } else {
+                telegramFacade.enviarMensagemSemMarkdown(userId, mensagem);
+            }
             log.info("✅ Transcrição entregue via cache para userId={} tipo={}", userId, tipo);
             return;
         }


### PR DESCRIPTION
## 📥 Pull Request: Correção de `raw_text` ausente e split de mensagem longa no cache (hotfix)

### 🧾 Descrição

Este hotfix resolve dois problemas identificados em produção:

1. **`table transcripts has no column named raw_text`**  
   - A tabela `transcripts` não possuía a coluna `raw_text`, impedindo o salvamento de transcrições brutas.  
   - O `DatabaseInitializer` foi melhorado para verificar a existência da coluna via `PRAGMA table_info` antes de tentar adicioná‑la, evitando exceções desnecessárias e garantindo a migração.

2. **`Bad Request: message is too long` ao entregar transcrição via cache**  
   - No fluxo de **cache hit** (quando a transcrição já estava armazenada), o bot enviava a mensagem diretamente sem verificar o limite de caracteres do Telegram (4096).  
   - Corrigido aplicando o mesmo `dividirMensagem` que já existe no fluxo normal.

### 📁 Arquivos alterados

- `src/main/java/net/ddns/adambravo79/tmill/config/DatabaseInitializer.java` – migração segura da coluna `raw_text`.
- `src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java` – split de mensagem longa no cache hit.

### 🧪 Como testar (após deploy)

1. **Verificar se a coluna `raw_text` existe**:
   ```bash
   sqlite3 data/t1000.db "PRAGMA table_info(transcripts);"
   ```
   Deve listar `raw_text` como uma das colunas.

2. **Testar mensagem longa com cache**:
   - Envie um áudio longo em grupo que gere transcrição grande (ex.: >4000 caracteres).  
   - Após o primeiro clique (processamento), o cache será populado.  
   - No segundo clique (qualquer outro), a mensagem deve ser dividida em partes e não gerar erro `message too long`.

### ✅ Checklist

- [x] Código revisado
- [x] Migração segura (usa `PRAGMA table_info` para evitar exceções)
- [x] Splitting de mensagem aplicado no cache hit
- [x] Testado localmente (simulado)
- [x] Sem conflitos com `main`
