### PR TITLE
Hotfix PR: Aumentar TTL dos tokens para 7 dias (evitar expiração prematura)

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java
@@ -110,10 +110,18 @@ public class TelegramController implements LongPollingUpdateConsumer {
         cleaner.scheduleAtFixedRate(
                 () -> {
                     long now = System.currentTimeMillis();
+                    int before = pendingGroupAudio.size();
+                    // Remove apenas tokens com mais de 7 dias (604800000 ms)
                     pendingGroupAudio
                             .entrySet()
-                            .removeIf(entry -> now - entry.getValue().timestamp() > 3600000);
-                    log.debug("🧹 Cache de tokens limpo. Tamanho: {}", pendingGroupAudio.size());
+                            .removeIf(entry -> now - entry.getValue().timestamp() > 604800000);
+                    int after = pendingGroupAudio.size();
+                    if (before != after) {
+                        log.info(
+                                "🧹 Cache de tokens limpo: {} entradas removidas, {} restantes",
+                                before - after,
+                                after);
+                    }
                 },
                 1,
                 1,
@@ -479,6 +487,7 @@ public class TelegramController implements LongPollingUpdateConsumer {
                 chatId, senderId, senderName, result.bruto(), result.refinado());
 
         String token = gerarToken(fileId);
+        log.info("🔑 Token {} gerado para fileId={} (expira em 7 dias)", token, fileId);
         pendingGroupAudio.put(
                 token,
                 new AudioRequest(fileId, chatId, System.currentTimeMillis(), senderId, senderName));


### PR DESCRIPTION
## 🔥 Hotfix PR: Aumentar TTL dos tokens para 7 dias (evitar expiração prematura)

### 🧾 Descrição

Os tokens gerados para os botões de transcrição em grupos expiravam após **1 hora**, causando o erro `Token inválido ou expirado` quando usuários clicavam em botões de áudios processados há mais de 60 minutos.  
Com este hotfix, o TTL (time‑to‑live) dos tokens é aumentado para **7 dias**, garantindo que os botões permaneçam funcionais por muito mais tempo.  

**Alterações:**
- No `TelegramController.init()`, o `cleaner` agora remove apenas tokens com mais de 604800000 ms (7 dias).  
- Logs adicionados para informar quantos tokens foram removidos e quantos restam.  
- Log de criação do token incluído para rastreabilidade.

### 🔗 Issue relacionada

- Relacionado a `Token inválido ou expirado` observado em produção.

### 🚀 Tipo de mudança

- [x] Bug fix  
- [ ] Nova feature  
- [ ] Refatoração

### 🧪 Como testar

1. Após o deploy, envie um áudio em grupo e aguarde o processamento (os botões aparecerão).  
2. Anote o horário.  
3. Aguarde mais de 1 hora (mas menos de 7 dias).  
4. Clique no botão – o token ainda deve ser válido e a transcrição deve ser entregue (cache hit).  
5. Verifique os logs:  
   - `🔑 Token ... gerado para fileId=... (expira em 7 dias)`  
   - Após 1 hora, nenhuma remoção indevida deve ocorrer (o log de limpeza só aparecerá após 7 dias).

### 📁 Arquivos alterados

- `src/main/java/net/ddns/adambravo79/tmill/controller/TelegramController.java`

### ✅ Checklist

- [x] Código revisado  
- [x] TTL aumentado para 7 dias  
- [x] Logs adicionados para monitoramento  
- [x] Testado localmente (simulado)
