### PR TITLE
✅ Pull Request: `release/v1.1.9` → `develop`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ data/**
 data/t1000.db
 src/main/resources/build-info.properties
 build-info.properties
+bump-version.sh

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ data/t1000.db
 src/main/resources/build-info.properties
 build-info.properties
 bump-version.sh
+release.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Bot para Telegram que **transcreve áudios** com IA (Whisper + refinamento Llama
 ![Build](https://img.shields.io/badge/build-passing-success)
 ![Tests](https://img.shields.io/badge/tests-coming_soon-yellow)
 ![License](https://img.shields.io/badge/license-MIT-blue)
-![Status](https://img.shields.io/badge/status-v1.1.8-blueviolet)
+![Status](https://img.shields.io/badge/status-v1.1.9-blueviolet)
 ![CI](https://github.com/andre-s-nascimento/t1000-bot/actions/workflows/ci.yml/badge.svg)
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'net.ddns.adambravo79'
-version = '1.1.8'
+version = '1.1.9'
 
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(21) }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'net.ddns.adambravo79'
-version = '1.1.9'
+version = '1.1.10'
 
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(21) }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'net.ddns.adambravo79'
-version = '1.1.10'
+version = '1.1.9'
 
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(21) }


### PR DESCRIPTION
## ✅ Pull Request: `release/v1.1.9` → `develop`

### 🧾 Descrição

Este PR traz as alterações da branch `release/v1.1.9` para a branch `develop`.  
A versão `v1.1.9` contém as seguintes mudanças:

- **Aumento do TTL dos tokens de áudio em grupo** de 1 hora para **7 dias**  
  → Corrige o erro `Token inválido ou expirado` quando usuários clicavam em botões de transcrição de áudios processados há mais de 60 minutos.
- **Bump de versão** nos arquivos `build.gradle`, `README.md` (badge) e `index.html`.

### 🔗 Issue relacionada

- Relacionado ao erro observado em produção (tokens expirando prematuramente).

### 🚀 Tipo de mudança

- [x] Bug fix  
- [x] Refatoração (TTL)

### 🧪 Como testar

1. Envie um áudio em grupo e aguarde o processamento.
2. Aguarde mais de 1 hora (mas menos de 7 dias).
3. Clique no botão de transcrição – a mensagem deve ser entregue sem erro de token expirado.
4. Verifique os logs: a mensagem `🔑 Token ... gerado para fileId=... (expira em 7 dias)` deve aparecer.

### ✅ Checklist

- [x] Código revisado  
- [x] TTL aumentado para 604800000 ms (7 dias)  
- [x] Logs de criação e limpeza de tokens adicionados  
- [x] Versão atualizada para `1.1.9`

---

## ✅ Pull Request: `release/v1.1.9` → `main`

### 🧾 Descrição

Este PR consolida a release `v1.1.9` na branch `main`, tornando as alterações disponíveis em produção.

**Conteúdo da release:**
- **Hotfix:** aumento do TTL dos tokens de áudio em grupo de 1 hora para 7 dias.
- **Bump de versão** para `1.1.9` nos arquivos de configuração e badges.

### 🔗 Issue relacionada

- Resolve o problema de expiração prematura de tokens (`Token inválido ou expirado`).

### 🚀 Tipo de mudança

- [x] Bug fix  
- [x] Release

### 🧪 Como testar (em produção)

1. Realize o merge deste PR na `main`.
2. Execute `./deploy-oci.sh deploy` no servidor OCI.
3. Envie um áudio em grupo e teste cliques após mais de 1 hora – o token deve permanecer válido.

### ✅ Checklist

- [x] Testes realizados em ambiente de homologação  
- [x] Versão atualizada  
- [x] Hotfix validado  