### PR TITLE
Hotfix: Erro de parse HTML no digest diário (Unexpected end tag)

### DIFF
--- a/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
+++ b/src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java
@@ -1,4 +1,4 @@
-/* (c) 2026 | 15/05/2026 */
+/* (c) 2026 | 18/05/2026 */
 package net.ddns.adambravo79.tmill.service;
 
 import java.time.Duration;
@@ -47,85 +47,57 @@ public class DailyDigestService {
 
     @PostConstruct
     public void init() {
-
         if (digestChatIdsStr != null && !digestChatIdsStr.isBlank()) {
-
             for (String s : digestChatIdsStr.split(",")) {
-
                 try {
-
                     digestChatIds.add(Long.parseLong(s.trim()));
-
                 } catch (NumberFormatException e) {
-
                     log.warn("ID inválido em digest.chat-ids: {}", s);
                 }
             }
-
             log.info("📊 Digests serão enviados para os chats: {}", digestChatIds);
-
         } else {
-
             log.info("Nenhum chat configurado para digest.");
         }
     }
 
     public void generateDigestCustom(LocalDateTime from, LocalDateTime to, Long specificChatId) {
-
         generateDigest(from, to, "PERÍODO PERSONALIZADO", specificChatId);
     }
 
     @Scheduled(cron = "0 30 8 * * *", zone = "America/Sao_Paulo")
     public void generateMorningDigest() {
-
         if (!digestEnabled || digestChatIds.isEmpty()) {
-
             return;
         }
-
         LocalDateTime now = LocalDateTime.now(ZoneId.of("America/Sao_Paulo"));
-
         LocalDateTime from = now.minusDays(1).withHour(20).withMinute(30).withSecond(0);
-
         LocalDateTime to = now.withHour(8).withMinute(30).withSecond(0);
-
         generateDigest(from, to, "RESUMO DA MADRUGADA/MANHÃ", null);
     }
 
     @Scheduled(cron = "0 30 20 * * *", zone = "America/Sao_Paulo")
     public void generateEveningDigest() {
-
         if (!digestEnabled || digestChatIds.isEmpty()) {
-
             return;
         }
-
         LocalDateTime now = LocalDateTime.now(ZoneId.of("America/Sao_Paulo"));
-
         LocalDateTime from = now.withHour(8).withMinute(30).withSecond(0);
-
         LocalDateTime to = now.withHour(20).withMinute(30).withSecond(0);
-
         generateDigest(from, to, "RESUMO DO DIA", null);
     }
 
     private void generateDigest(
             LocalDateTime from, LocalDateTime to, String periodLabel, Long specificChatId) {
-
         log.info("Gerando {} | {} -> {}", periodLabel, from, to);
 
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
         List<Map<String, Object>> messages =
                 jdbcTemplate.queryForList(
                         """
-            SELECT
-              user_name,
-              text,
-              timestamp
+            SELECT user_name, text, timestamp
             FROM messages
-            WHERE datetime(timestamp, 'localtime')
-            BETWEEN ? AND ?
+            WHERE datetime(timestamp, 'localtime') BETWEEN ? AND ?
             ORDER BY timestamp ASC
             """,
                         from.format(dtf),
@@ -134,29 +106,21 @@ public class DailyDigestService {
         List<Map<String, Object>> transcripts =
                 jdbcTemplate.queryForList(
                         """
-            SELECT
-              user_name,
-              text,
-              timestamp
+            SELECT user_name, text, timestamp
             FROM transcripts
-            WHERE datetime(timestamp, 'localtime')
-            BETWEEN ? AND ?
+            WHERE datetime(timestamp, 'localtime') BETWEEN ? AND ?
             ORDER BY timestamp ASC
             """,
                         from.format(dtf),
                         to.format(dtf));
 
         if (messages.isEmpty() && transcripts.isEmpty()) {
-
             log.info("Nenhuma interação encontrada.");
-
             return;
         }
 
         List<ChatMessage> allMessages = new ArrayList<>();
-
         for (Map<String, Object> row : messages) {
-
             allMessages.add(
                     ChatMessage.builder()
                             .user((String) row.get("user_name"))
@@ -165,9 +129,7 @@ public class DailyDigestService {
                             .audio(false)
                             .build());
         }
-
         for (Map<String, Object> row : transcripts) {
-
             allMessages.add(
                     ChatMessage.builder()
                             .user((String) row.get("user_name"))
@@ -180,80 +142,58 @@ public class DailyDigestService {
         allMessages.sort(Comparator.comparing(ChatMessage::getTimestamp));
 
         String finalMessages = buildMessagesBlock(allMessages);
-
         if (finalMessages.length() > MAX_PROMPT_SIZE) {
-
             int allowedMessagesSize = MAX_PROMPT_SIZE - 4000;
-
             log.warn(
                     "✂️ Mensagens truncadas de {} para {} chars",
                     finalMessages.length(),
                     allowedMessagesSize);
-
             int slice = allowedMessagesSize / 3;
-
             String start = finalMessages.substring(0, Math.min(slice, finalMessages.length()));
-
             String middle =
                     finalMessages.substring(
                             Math.max(0, (finalMessages.length() / 2) - (slice / 2)),
                             Math.min(
                                     finalMessages.length(),
                                     (finalMessages.length() / 2) + (slice / 2)));
-
             String end = finalMessages.substring(Math.max(0, finalMessages.length() - slice));
-
             finalMessages = start + "\n\n[...]\n\n" + middle + "\n\n[...]\n\n" + end;
         }
 
         log.info("📦 Mensagens finais size={}", finalMessages.length());
 
         try {
-
             DigestPersona persona = DigestPersona.T1000;
-
             String summary = groqClient.gerarResumoDigest(finalMessages, persona, periodLabel);
-
             if (summary == null || summary.isBlank()) {
-
                 log.warn("Resumo vazio.");
-
                 return;
             }
 
             String finalMessage = buildHeader(periodLabel, from, to) + sanitizeHtml(summary);
-
             Set<Long> targets = specificChatId != null ? Set.of(specificChatId) : digestChatIds;
-
             for (Long chatId : targets) {
                 sendDigestToChat(chatId, finalMessage);
             }
-
         } catch (Exception e) {
-
             log.error("❌ Erro ao gerar digest", e);
         }
     }
 
     private String buildMessagesBlock(List<ChatMessage> messages) {
-
         StringBuilder sb = new StringBuilder();
         DateTimeFormatter hourFormat = DateTimeFormatter.ofPattern("HH:mm");
         LocalDateTime previous = null;
-
         for (ChatMessage msg : messages) {
             LocalDateTime current = LocalDateTime.parse(msg.getTimestamp().replace(" ", "T"));
-
             if (previous != null) {
                 long diff = Duration.between(previous, current).toMinutes();
                 if (diff >= 20) {
-
                     sb.append("\n==============================\n");
                     sb.append("NOVO BLOCO DE CONVERSA\n");
                     sb.append("==============================\n\n");
                 }
             }
-
             String line =
                     String.format(
                             "[%s] %s%s: %s%n",
@@ -261,19 +201,14 @@ public class DailyDigestService {
                             msg.getUser(),
                             msg.isAudio() ? " (áudio)" : "",
                             msg.getText());
-
             sb.append(line);
-
             previous = current;
         }
-
         return sb.toString();
     }
 
     private String buildHeader(String periodLabel, LocalDateTime from, LocalDateTime to) {
-
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
-
         return String.format(
                 """
         <b>📊 %s</b>
@@ -284,40 +219,54 @@ public class DailyDigestService {
     }
 
     private String sanitizeHtml(String text) {
-
-        if (text == null) {
-
-            return "";
-        }
-
-        return text.replace("&", "&amp;")
-                .replace("<b>", "##B_OPEN##")
-                .replace("</b>", "##B_CLOSE##")
-                .replace("<i>", "##I_OPEN##")
-                .replace("</i>", "##I_CLOSE##")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("##B_OPEN##", "<b>")
-                .replace("##B_CLOSE##", "</b>")
-                .replace("##I_OPEN##", "<i>")
-                .replace("##I_CLOSE##", "</i>");
+        if (text == null) return "";
+        // Remove tags HTML que estão abertas e não fechadas? Não vamos tentar consertar.
+        // Apenas escapamos &, <, > (exceto <b>, <i>, </b>, </i> que precisamos preservar).
+        // Usamos placeholders para proteger as tags permitidas.
+        String temp =
+                text.replace("<b>", "##B_OPEN##")
+                        .replace("</b>", "##B_CLOSE##")
+                        .replace("<i>", "##I_OPEN##")
+                        .replace("</i>", "##I_CLOSE##");
+        temp = temp.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        temp =
+                temp.replace("##B_OPEN##", "<b>")
+                        .replace("##B_CLOSE##", "</b>")
+                        .replace("##I_OPEN##", "<i>")
+                        .replace("##I_CLOSE##", "</i>");
+        return temp;
     }
 
     @Data
     @Builder
     private static class ChatMessage {
-
         private String user;
         private String text;
         private String timestamp;
         private boolean audio;
     }
 
+    /**
+     * Envia o digest para um chat específico, tentando com HTML primeiro. Se houver erro de parse
+     * (tags não fechadas), reenvia o mesmo conteúdo em texto puro.
+     */
     private void sendDigestToChat(Long chatId, String finalMessage) {
         try {
             List<String> chunks = TelegramMessageSplitter.split(finalMessage);
             for (String chunk : chunks) {
-                telegramFacade.enviarMensagemHtml(chatId, chunk);
+                try {
+                    telegramFacade.enviarMensagemHtml(chatId, chunk);
+                } catch (Exception e) {
+                    // Se falhar por parse de entidades, reenvia o mesmo chunk sem parse_mode
+                    if (e.getMessage() != null && e.getMessage().contains("can't parse entities")) {
+                        log.warn(
+                                "⚠️ Erro de parse HTML, reenviando como texto puro para chatId={}",
+                                chatId);
+                        telegramFacade.enviarMensagem(chatId, chunk);
+                    } else {
+                        throw e;
+                    }
+                }
             }
             log.info("✅ Digest enviado chatId={}", chatId);
         } catch (Exception e) {


### PR DESCRIPTION
## 🐛 Hotfix: Erro de parse HTML no digest diário (Unexpected end tag)

### 🧾 Descrição

O resumo diário (digest) está falhando com o erro `can't parse entities: Unexpected end tag at byte offset 1743` porque a IA gerou HTML incompleto (ex.: `<b>texto` sem fechar a tag, ou `<i>` sem `</i>`). A mensagem é enviada com `parse_mode=HTML`, e o Telegram rejeita tags não fechadas.

**Solução:**  
- Capturar a exceção de parse e, em caso de erro, **reenviar o mesmo resumo em texto puro** (sem `parse_mode`), mantendo o conteúdo legível mesmo sem formatação.
- Adicionar uma validação simples que conta tags HTML de abertura/fechamento, mas por simplicidade, o fallback é mais seguro.

### 📁 Arquivo alterado

- `src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java`

### 🔧 Código corrigido

No método `generateDigest`, substitua o bloco de envio (dentro do loop `for (Long chatId : targetChats)`) por:

```java
for (Long chatId : targetChats) {
    try {
        telegramFacade.enviarMensagemHtml(chatId, finalMessage);
        log.info("Resumo enviado para chatId={}", chatId);
    } catch (Exception e) {
        if (e.getMessage() != null && e.getMessage().contains("can't parse entities")) {
            log.warn("Erro de parse HTML, reenviando sem formatação para chatId={}", chatId);
            telegramFacade.enviarMensagem(chatId, finalMessage);
        } else {
            log.error("Erro ao enviar resumo para chatId={}", chatId, e);
        }
    }
}
```

**Alternativa mais robusta (opcional):**  
Antes de enviar, tentar fechar tags abertas usando um parser como Jsoup, mas o fallback acima é suficiente.

### 🧪 Como testar

1. Simule uma resposta da IA que contenha HTML mal formatado (ex.: `"<b>texto sem fechar"`).  
2. O bot deve tentar enviar com HTML, falhar, e reenviar a mesma mensagem em texto puro.  
3. O usuário recebe o conteúdo sem formatação, mas sem erro.

### ✅ Checklist

- [x] Código revisado  
- [x] Fallback seguro (não quebra o digest)  
- [x] Logs informativos (WARN para o fallback)  

---## 🐛 Hotfix: Erro de parse HTML no digest diário (Unexpected end tag)

### 🧾 Descrição

O resumo diário (digest) está falhando com o erro `can't parse entities: Unexpected end tag at byte offset 1743` porque a IA gerou HTML incompleto (ex.: `<b>texto` sem fechar a tag, ou `<i>` sem `</i>`). A mensagem é enviada com `parse_mode=HTML`, e o Telegram rejeita tags não fechadas.

**Solução:**  
- Capturar a exceção de parse e, em caso de erro, **reenviar o mesmo resumo em texto puro** (sem `parse_mode`), mantendo o conteúdo legível mesmo sem formatação.
- Adicionar uma validação simples que conta tags HTML de abertura/fechamento, mas por simplicidade, o fallback é mais seguro.

### 📁 Arquivo alterado

- `src/main/java/net/ddns/adambravo79/tmill/service/DailyDigestService.java`

### 🔧 Código corrigido

No método `generateDigest`, substitua o bloco de envio (dentro do loop `for (Long chatId : targetChats)`) por:

```java
for (Long chatId : targetChats) {
    try {
        telegramFacade.enviarMensagemHtml(chatId, finalMessage);
        log.info("Resumo enviado para chatId={}", chatId);
    } catch (Exception e) {
        if (e.getMessage() != null && e.getMessage().contains("can't parse entities")) {
            log.warn("Erro de parse HTML, reenviando sem formatação para chatId={}", chatId);
            telegramFacade.enviarMensagem(chatId, finalMessage);
        } else {
            log.error("Erro ao enviar resumo para chatId={}", chatId, e);
        }
    }
}
```

**Alternativa mais robusta (opcional):**  
Antes de enviar, tentar fechar tags abertas usando um parser como Jsoup, mas o fallback acima é suficiente.

### 🧪 Como testar

1. Simule uma resposta da IA que contenha HTML mal formatado (ex.: `"<b>texto sem fechar"`).  
2. O bot deve tentar enviar com HTML, falhar, e reenviar a mesma mensagem em texto puro.  
3. O usuário recebe o conteúdo sem formatação, mas sem erro.

### ✅ Checklist

- [x] Código revisado  
- [x] Fallback seguro (não quebra o digest)  
- [x] Logs informativos (WARN para o fallback)  